### PR TITLE
Updated attacher to version v3.4.0

### DIFF
--- a/deploy/kubernetes/attacher.yaml
+++ b/deploy/kubernetes/attacher.yaml
@@ -24,6 +24,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -75,7 +78,7 @@ spec:
         operator: "Exists"
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.2.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
           args:
             - "--v=4"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
The current csi-attacher (v2.2.0) doesn't work on Kubernetes 1.22+ because VolumeAttachment v1beta1 no longer served, so I suggest to use the latest vesrion (v3.4.0) - https://kubernetes.io/docs/reference/using-api/deprecation-guide/#storage-resources-v122

Additionaly, the last versions of csi-attacher need additional rbac rule - https://github.com/kubernetes-csi/external-attacher/blob/master/deploy/kubernetes/rbac.yaml

P.S. It seem like the last versions of csi-attacher aren't pushed on quay.io anymore.