### PR TITLE
Add support for optional secrets

### DIFF
--- a/deploy/helm/templates/secret.yaml
+++ b/deploy/helm/templates/secret.yaml
@@ -5,7 +5,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Values.secret.name }}
 stringData:
+{{- if .Values.secret.accessKey }}
   accessKeyID: {{ .Values.secret.accessKey }}
+{{- end }}
+{{- if .Values.secret.secretKey }}
   secretAccessKey: {{ .Values.secret.secretKey }}
+{{- end }}
   endpoint: {{ .Values.secret.endpoint }}
 {{- end -}}


### PR DESCRIPTION
Allow secrets to be optional when using IAM.

~This PR makes the mounter configurable. (A configurable mounter is useful because we are trying to transition from s3fs to geesefs, and support both in the interim if possible)~
