### PR TITLE
Added support for a custom prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ stringData:
   endpoint: https://storage.yandexcloud.net
   # For AWS set it to AWS region
   #region: ""
+  # 'usePrefix' must be true in order to enable the prefix feature and to avoid the removal of the prefix or bucket
+  usePrefix: "true"
+  # 'prefix' can be empty (it will mount on the root of the bucket), an existing prefix or a new one.
+  prefix: custom-prefix
 ```
 
 The region can be empty if you are using some other S3 compatible storage.

--- a/deploy/helm/templates/secret.yaml
+++ b/deploy/helm/templates/secret.yaml
@@ -9,3 +9,7 @@ stringData:
   secretAccessKey: {{ .Values.secret.secretKey }}
   endpoint: {{ .Values.secret.endpoint }}
 {{- end -}}
+{{- if .Values.secret.usePrefix }}
+  usePrefix: "true"
+{{- end }}
+  prefix: "{{ .Values.secret.prefix }}"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -37,3 +37,7 @@ secret:
   secretKey: ""
   # Endpoint
   endpoint: https://storage.yandexcloud.net
+  # 'usePrefix' must be true in order to enable the prefix feature and to avoid the removal of the prefix or bucket
+  usePrefix:
+  # 'prefix' can be empty (it will mount on the root of the bucket), an existing prefix or a new one.
+  prefix:

--- a/pkg/mounter/mounter.go
+++ b/pkg/mounter/mounter.go
@@ -32,6 +32,8 @@ const (
 	TypeKey             = "mounter"
 	BucketKey           = "bucket"
 	OptionsKey          = "options"
+	VolumePrefix        = "prefix"
+	UsePrefix           = "usePrefix"
 )
 
 // New returns a new mounter depending on the mounterType parameter


### PR DESCRIPTION
Closes: https://github.com/yandex-cloud/k8s-csi-s3/issues/12

This PR adds back support for an optional custom prefix. Custom prefixes are useful if simply mounting data from an existing bucket.

I ended up using a csi secret instead of StorageClass to pass `usePrefix`, as the `DeleteVolume` method does not receive storageclass parameters. This seemed like a reasonable compromise over using metadata as the ctrox-s3 driver is doing, but I'd be happy to hear suggestions, as I haven't worked much with csi drivers before.