### PR TITLE
Toleration fix for helm chart and yaml.

### DIFF
--- a/deploy/helm/templates/csi-s3.yaml
+++ b/deploy/helm/templates/csi-s3.yaml
@@ -52,6 +52,15 @@ spec:
       labels:
         app: csi-s3
     spec:
+      {{- if .Values.tolerations.create }}
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+      {{- end }}
       serviceAccount: csi-s3
       hostNetwork: true
       containers:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -37,3 +37,7 @@ secret:
   secretKey: ""
   # Endpoint
   endpoint: https://storage.yandexcloud.net
+ 
+tolerations:
+  # Specifies whether the tolerations for Yandex Cloud should be created (CriticalAddonsOnly)
+  create: true

--- a/deploy/kubernetes/csi-s3.yaml
+++ b/deploy/kubernetes/csi-s3.yaml
@@ -52,6 +52,13 @@ spec:
       labels:
         app: csi-s3
     spec:
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists    
       serviceAccount: csi-s3
       hostNetwork: true
       containers:


### PR DESCRIPTION
Also adding tolerations as an option in values.yaml, the current default tolerations prevent the normal distributions across all nodes of the cluster. 