### PR TITLE
Fail to mount bounded pvc

### DIFF
--- a/deploy/helm/templates/attacher.yaml
+++ b/deploy/helm/templates/attacher.yaml
@@ -79,6 +79,13 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: "Exists"
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                  app: csi-provisioner-s3
+            topologyKey: kubernetes.io/hostname
       containers:
         - name: csi-attacher
           image: {{ .Values.images.attacher }}

--- a/deploy/helm/templates/provisioner.yaml
+++ b/deploy/helm/templates/provisioner.yaml
@@ -56,6 +56,8 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-provisioner-s3
+  labels:
+    app: csi-provisioner-s3
   namespace: {{ .Release.Namespace }}
 spec:
   serviceName: "csi-provisioner-s3"
@@ -112,4 +114,6 @@ spec:
               mountPath: /var/lib/kubelet/plugins/ru.yandex.s3.csi
       volumes:
         - name: socket-dir
-          emptyDir: {}
+          hostPath:
+            path: /var/lib/kubelet/plugins/ru.yandex.s3.csi
+            type: DirectoryOrCreate

--- a/deploy/kubernetes/attacher.yaml
+++ b/deploy/kubernetes/attacher.yaml
@@ -84,6 +84,13 @@ spec:
         - operator: Exists
           effect: NoExecute
           tolerationSeconds: 300
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                  app: csi-provisioner-s3
+            topologyKey: kubernetes.io/hostname
       containers:
         - name: csi-attacher
           image: quay.io/k8scsi/csi-attacher:v3.0.1

--- a/deploy/kubernetes/provisioner.yaml
+++ b/deploy/kubernetes/provisioner.yaml
@@ -104,4 +104,6 @@ spec:
               mountPath: /var/lib/kubelet/plugins/ru.yandex.s3.csi
       volumes:
         - name: socket-dir
-          emptyDir: {}
+          hostPath:
+            path: /var/lib/kubelet/plugins/ru.yandex.s3.csi
+            type: DirectoryOrCreate

--- a/deploy/kubernetes/provisioner.yaml
+++ b/deploy/kubernetes/provisioner.yaml
@@ -56,6 +56,8 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-provisioner-s3
+  labels:
+    app: csi-provisioner-s3
   namespace: kube-system
 spec:
   serviceName: "csi-provisioner-s3"


### PR DESCRIPTION
There are nothing shows in attacher's log after start a pod which mount pvc that created by csi-provisioner-s3.
According to CSI [architect](https://discuss.kubernetes.io/t/understanding-csi-architecture-and-communication/9404/2), provisioner and attacher needs to communicate with each other. 

[provisioner.yaml](https://github.com/yandex-cloud/k8s-csi-s3/tree/master/deploy/kubernetes/provisioner.yaml) needs to mount socket file on host rather than a emptyDir and attcher need to see the same socket file, I use affinity to make attacher to be deployed to the node of provisioner runs. 

It has been tested on following env:
Kubernetes: 1.23, 1.19
S3 Backend: minI/O

This PR is related to #24 #5  