### PR TITLE
add manual pvc mount options

### DIFF
--- a/deploy/kubernetes/examples/pvc-manual.yaml
+++ b/deploy/kubernetes/examples/pvc-manual.yaml
@@ -29,6 +29,7 @@ spec:
     volumeAttributes:
       capacity: 10Gi
       mounter: geesefs
+      options: --memory-limit 1000 --dir-mode 0777 --file-mode 0666
     volumeHandle: manualbucket/path
 ---
 apiVersion: v1


### PR DESCRIPTION
It will lose mount options when using pvc-manual.yaml to mount existing bucket, add volumeAttributes.options in example.