### PR TITLE
Delete taint for provisioner

### DIFF
--- a/deploy/helm/templates/provisioner.yaml
+++ b/deploy/helm/templates/provisioner.yaml
@@ -72,11 +72,6 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           operator: Exists
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - operator: Exists
-          effect: NoExecute
-          tolerationSeconds: 300
         {{- with .Values.tolerations.controller }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
This taint not deleted from helm-chart and can broke deploy with helm-chart, if node have some taint with No_Execute. I think it must be delete and don't need.  