### PR TITLE
add a `kubeletPath` option to `values.yaml`

### DIFF
--- a/deploy/helm/templates/attacher.yaml
+++ b/deploy/helm/templates/attacher.yaml
@@ -89,13 +89,13 @@ spec:
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
-              value: /var/lib/kubelet/plugins/ru.yandex.s3.csi/csi.sock
+              value: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi/csi.sock
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/kubelet/plugins/ru.yandex.s3.csi
+              mountPath: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi
       volumes:
         - name: socket-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/ru.yandex.s3.csi
+            path: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi
             type: DirectoryOrCreate

--- a/deploy/helm/templates/csi-s3.yaml
+++ b/deploy/helm/templates/csi-s3.yaml
@@ -62,7 +62,7 @@ spec:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: /var/lib/kubelet/plugins/ru.yandex.s3.csi/csi.sock
+              value: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -95,22 +95,22 @@ spec:
             - name: plugin-dir
               mountPath: /csi
             - name: pods-mount-dir
-              mountPath: /var/lib/kubelet/pods
+              mountPath: {{ .Values.kubeletPath }}/pods
               mountPropagation: "Bidirectional"
             - name: fuse-device
               mountPath: /dev/fuse
       volumes:
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry/
+            path: {{ .Values.kubeletPath }}/plugins_registry/
             type: DirectoryOrCreate
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/ru.yandex.s3.csi
+            path: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi
             type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
-            path: /var/lib/kubelet/pods
+            path: {{ .Values.kubeletPath }}/pods
             type: Directory
         - name: fuse-device
           hostPath:

--- a/deploy/helm/templates/provisioner.yaml
+++ b/deploy/helm/templates/provisioner.yaml
@@ -85,11 +85,11 @@ spec:
             - "--v=4"
           env:
             - name: ADDRESS
-              value: /var/lib/kubelet/plugins/ru.yandex.s3.csi/csi.sock
+              value: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi/csi.sock
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/kubelet/plugins/ru.yandex.s3.csi
+              mountPath: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi
         - name: csi-s3
           image: {{ .Values.images.csi }}
           imagePullPolicy: IfNotPresent
@@ -99,14 +99,14 @@ spec:
             - "--v=4"
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/kubelet/plugins/ru.yandex.s3.csi/csi.sock
+              value: unix://{{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi/csi.sock
             - name: NODE_ID
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/kubelet/plugins/ru.yandex.s3.csi
+              mountPath: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -42,3 +42,5 @@ tolerations:
   all: false
   node: []
   controller: []
+
+kubeletPath: {{ .Values.kubeletPath }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -43,4 +43,4 @@ tolerations:
   node: []
   controller: []
 
-kubeletPath: {{ .Values.kubeletPath }}
+kubeletPath: /var/lib/kubelet


### PR DESCRIPTION
This PR makes the path to the Kubelet folder on the host configurable. Some Kubernetes distributions use a different path, such as k0s, where the folder lives in `/var/lib/k0s/kubelet` instead.