### PR TITLE
Don't call os.Setenv()

### DIFF
--- a/pkg/mounter/geesefs.go
+++ b/pkg/mounter/geesefs.go
@@ -75,9 +75,11 @@ func (geesefs *geesefsMounter) MountDirect(target string, args []string) error {
 		"-o", "allow_other",
 		"--log-file", "/dev/stderr",
 	}, args...)
-	os.Setenv("AWS_ACCESS_KEY_ID", geesefs.accessKeyID)
-	os.Setenv("AWS_SECRET_ACCESS_KEY", geesefs.secretAccessKey)
-	return fuseMount(target, geesefsCmd, args)
+	envs := []string{
+		"AWS_ACCESS_KEY_ID=" + geesefs.accessKeyID,
+		"AWS_SECRET_ACCESS_KEY=" + geesefs.secretAccessKey,
+	}
+	return fuseMount(target, geesefsCmd, args, envs)
 }
 
 type execCmd struct {

--- a/pkg/mounter/mounter.go
+++ b/pkg/mounter/mounter.go
@@ -57,9 +57,11 @@ func New(meta *s3.FSMeta, cfg *s3.Config) (Mounter, error) {
 	}
 }
 
-func fuseMount(path string, command string, args []string) error {
+func fuseMount(path string, command string, args []string, envs []string) error {
 	cmd := exec.Command(command, args...)
 	cmd.Stderr = os.Stderr
+	// cmd.Environ() returns envs inherited from the current process
+	cmd.Env = append(cmd.Environ(), envs...)
 	glog.V(3).Infof("Mounting fuse with command: %s and args: %s", command, args)
 
 	out, err := cmd.Output()

--- a/pkg/mounter/rclone.go
+++ b/pkg/mounter/rclone.go
@@ -47,7 +47,9 @@ func (rclone *rcloneMounter) Mount(target, volumeID string) error {
 		args = append(args, fmt.Sprintf("--s3-region=%s", rclone.region))
 	}
 	args = append(args, rclone.meta.MountOptions...)
-	os.Setenv("AWS_ACCESS_KEY_ID", rclone.accessKeyID)
-	os.Setenv("AWS_SECRET_ACCESS_KEY", rclone.secretAccessKey)
-	return fuseMount(target, rcloneCmd, args)
+	envs := []string{
+		"AWS_ACCESS_KEY_ID=" + rclone.accessKeyID,
+		"AWS_SECRET_ACCESS_KEY=" + rclone.secretAccessKey,
+	}
+	return fuseMount(target, rcloneCmd, args, envs)
 }

--- a/pkg/mounter/s3fs.go
+++ b/pkg/mounter/s3fs.go
@@ -44,7 +44,7 @@ func (s3fs *s3fsMounter) Mount(target, volumeID string) error {
 		args = append(args, "-o", fmt.Sprintf("endpoint=%s", s3fs.region))
 	}
 	args = append(args, s3fs.meta.MountOptions...)
-	return fuseMount(target, s3fsCmd, args)
+	return fuseMount(target, s3fsCmd, args, nil)
 }
 
 func writes3fsPass(pwFileContent string) error {


### PR DESCRIPTION
The CSI driver passes S3 credentials to geesefs or rclone through `os.Setenv()`. When the CSI driver mounts two volumes at the same time but they use different S3 credentials, using `os.Setenv()` may cause the environment variables to be accidentally overwritten. Passing the env array directly into the `exec.Cmd` structure can avoid this problem.