### PR TITLE
Fix the wrong argument for credentials.NewStaticV4()

### DIFF
--- a/pkg/mounter/rclone.go
+++ b/pkg/mounter/rclone.go
@@ -2,7 +2,6 @@ package mounter
 
 import (
 	"fmt"
-	"os"
 	"path"
 
 	"github.com/yandex-cloud/k8s-csi-s3/pkg/s3"

--- a/pkg/s3/client.go
+++ b/pkg/s3/client.go
@@ -52,7 +52,7 @@ func NewClient(cfg *Config) (*s3Client, error) {
 		endpoint = u.Hostname() + ":" + u.Port()
 	}
 	minioClient, err := minio.New(endpoint, &minio.Options{
-		Creds:  credentials.NewStaticV4(client.Config.AccessKeyID, client.Config.SecretAccessKey, client.Config.Region),
+		Creds:  credentials.NewStaticV4(client.Config.AccessKeyID, client.Config.SecretAccessKey, ""),
 		Secure: ssl,
 	})
 	if err != nil {


### PR DESCRIPTION
The third argument for `credentials.NewStaticV4()` is a "token" but not a "region".

ref:
* https://pkg.go.dev/github.com/minio/minio-go/pkg/credentials#NewStaticV4
* https://min.io/docs/minio/linux/developers/go/API.html