### PR TITLE
feat: add nodeSelector for provisioner

### DIFF
--- a/deploy/helm/templates/provisioner.yaml
+++ b/deploy/helm/templates/provisioner.yaml
@@ -77,6 +77,10 @@ spec:
         {{- with .Values.tolerations.controller }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: csi-provisioner
           image: {{ .Values.images.provisioner }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -43,4 +43,6 @@ tolerations:
   node: []
   controller: []
 
+nodeSelector: {}
+
 kubeletPath: /var/lib/kubelet


### PR DESCRIPTION
it would be useful to add `nodeSelector` to control provisioner pods targeting