### PR TITLE
Actualize outdated Helm template for csi-s3 DaemonSet

### DIFF
--- a/deploy/helm/templates/csi-s3.yaml
+++ b/deploy/helm/templates/csi-s3.yaml
@@ -99,6 +99,8 @@ spec:
               mountPropagation: "Bidirectional"
             - name: fuse-device
               mountPath: /dev/fuse
+            - name: systemd-control
+              mountPath: /run/systemd
       volumes:
         - name: registration-dir
           hostPath:
@@ -115,3 +117,7 @@ spec:
         - name: fuse-device
           hostPath:
             path: /dev/fuse
+        - name: systemd-control
+          hostPath:
+            path: /run/systemd
+            type: DirectoryOrCreate

--- a/deploy/helm/templates/csi-s3.yaml
+++ b/deploy/helm/templates/csi-s3.yaml
@@ -94,6 +94,9 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+            - name: stage-dir
+              mountPath: {{ .Values.kubeletPath }}/plugins/kubernetes.io/csi
+              mountPropagation: "Bidirectional"
             - name: pods-mount-dir
               mountPath: {{ .Values.kubeletPath }}/pods
               mountPropagation: "Bidirectional"
@@ -109,6 +112,10 @@ spec:
         - name: plugin-dir
           hostPath:
             path: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi
+            type: DirectoryOrCreate
+        - name: stage-dir
+          hostPath:
+            path: {{ .Values.kubeletPath }}/plugins/kubernetes.io/csi
             type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:


### PR DESCRIPTION
Mirrors changes made to Kubernetes manifests that are missing in respective Helm template file as described in https://github.com/yandex-cloud/k8s-csi-s3/issues/62