### PR TITLE
Fix geesefs path in Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ LABEL description="csi-s3 slim image"
 RUN apk add --no-cache fuse
 #RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/community rclone s3fs-fuse
 
-ADD https://github.com/yandex-cloud/geesefs/releases/latest/download/geesefs-linux-amd64 /usr/bin/geesefs
-RUN chmod 755 /usr/bin/geesefs
+ADD https://github.com/yandex-cloud/geesefs/releases/latest/download/geesefs-linux-amd64 /var/lib/kubelet/plugins/ru.yandex.s3.csi/geesefs
+RUN chmod 755 /var/lib/kubelet/plugins/ru.yandex.s3.csi/geesefs
 
 COPY --from=gobuild /build/s3driver /s3driver
 ENTRYPOINT ["/s3driver"]


### PR DESCRIPTION
Fix geesefs path, which in current version doesn't work and user will see timeout message in the logs