### PR TITLE
Add /etc/mime.types to csi-s3 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM alpine:3.17
 LABEL maintainers="Vitaliy Filippov <vitalif@yourcmc.ru>"
 LABEL description="csi-s3 slim image"
 
-RUN apk add --no-cache fuse rclone
+RUN apk add --no-cache fuse mailcap rclone
 RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/community s3fs-fuse
 
 ADD https://github.com/yandex-cloud/geesefs/releases/latest/download/geesefs-linux-amd64 /usr/bin/geesefs


### PR DESCRIPTION
I need to use the `--use-content-type` option for `geesefs`, but it doesn't work because there is no `/etc/mime.types` file in the image. (It required by geesefs to determine the content type).

This patch adds the installation of the `mailcap` package, which provides the necessary file and solve the problem.