### PR TITLE
Fix the concurrency issues in `removeObjectsOneByOne`

### DIFF
--- a/pkg/s3/client.go
+++ b/pkg/s3/client.go
@@ -197,15 +197,15 @@ func (client *s3Client) removeObjectsOneByOne(bucketName, prefix string) error {
 
 	for object := range objectsCh {
 		guardCh <- 1
-		go func() {
-			err := client.minio.RemoveObject(client.ctx, bucketName, object.Key,
-				minio.RemoveObjectOptions{VersionID: object.VersionID})
+		go func(obj minio.ObjectInfo) {
+			err := client.minio.RemoveObject(client.ctx, bucketName, obj.Key,
+				minio.RemoveObjectOptions{VersionID: obj.VersionID})
 			if err != nil {
-				glog.Errorf("Failed to remove object %s, error: %s", object.Key, err)
+				glog.Errorf("Failed to remove object %s, error: %s", obj.Key, err)
 				removeErrors++
 			}
 			<- guardCh
-		}()
+		}(object)
 	}
 	for i := 0; i < parallelism; i++ {
 		guardCh <- 1


### PR DESCRIPTION
Hi there!

This PR fixes some obvious concurrency issues in function that tries to remove objects asynchronously:
- goroutine variable capturing in for-loop
- unsafe incrementing of counters

I had experienced some troubles with tests (minio server build failed, go 1.15 toolkit doesn't have `cmd.Environ()`) that is completely unrelated with my changes and as soon as I fixed it, everything worked fine.