### PR TITLE
ADD local host connection minio

### DIFF
--- a/deploy/helm/csi-s3/templates/csi-s3.yaml
+++ b/deploy/helm/csi-s3/templates/csi-s3.yaml
@@ -84,6 +84,13 @@ spec:
             - "--nodeid=$(NODE_ID)"
             - "--v=4"
           env:
+            - name: MY_POD_HOST_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+            - name: MINIO_PORT
+              value: "{{ .Values.minio.port }}"
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             - name: NODE_ID

--- a/deploy/helm/csi-s3/values.yaml
+++ b/deploy/helm/csi-s3/values.yaml
@@ -39,6 +39,8 @@ secret:
   endpoint: https://storage.yandexcloud.net
   # Region
   region: ""
+  # Minio
+  minio: disable
 
 tolerations:
   all: false
@@ -48,3 +50,6 @@ tolerations:
 nodeSelector: {}
 
 kubeletPath: /var/lib/kubelet
+
+minio:
+  port: 30080

--- a/pkg/mounter/geesefs.go
+++ b/pkg/mounter/geesefs.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	geesefsCmd    = "geesefs"
+	geesefsCmd = "geesefs"
 )
 
 // Implements Mounter
@@ -24,6 +24,7 @@ type geesefsMounter struct {
 	region          string
 	accessKeyID     string
 	secretAccessKey string
+	minio           string
 }
 
 func newGeeseFSMounter(meta *s3.FSMeta, cfg *s3.Config) (Mounter, error) {
@@ -33,6 +34,7 @@ func newGeeseFSMounter(meta *s3.FSMeta, cfg *s3.Config) (Mounter, error) {
 		region:          cfg.Region,
 		accessKeyID:     cfg.AccessKeyID,
 		secretAccessKey: cfg.SecretAccessKey,
+		minio:           cfg.Minio,
 	}, nil
 }
 
@@ -70,6 +72,9 @@ func (geesefs *geesefsMounter) CopyBinary(from, to string) error {
 }
 
 func (geesefs *geesefsMounter) MountDirect(target string, args []string) error {
+	if geesefs.minio == "enable" {
+		geesefs.endpoint = "http://" + os.Getenv("MY_POD_HOST_IP") + ":" + os.Getenv("MINIO_PORT")
+	}
 	args = append([]string{
 		"--endpoint", geesefs.endpoint,
 		"-o", "allow_other",
@@ -143,21 +148,27 @@ func (geesefs *geesefsMounter) Mount(target, volumeID string) error {
 	if pluginDir == "" {
 		pluginDir = "/var/lib/kubelet/plugins/ru.yandex.s3.csi"
 	}
-	args = append([]string{pluginDir+"/geesefs", "-f", "-o", "allow_other", "--endpoint", geesefs.endpoint}, args...)
-	glog.Info("Starting geesefs using systemd: "+strings.Join(args, " "))
-	unitName := "geesefs-"+systemd.PathBusEscape(volumeID)+".service"
+
+	if geesefs.minio == "enable" {
+		geesefs.endpoint = "http://" + os.Getenv("MY_POD_HOST_IP") + ":" + os.Getenv("MINIO_PORT")
+		glog.Info("minio url: ", geesefs.endpoint)
+	}
+
+	args = append([]string{pluginDir + "/geesefs", "-f", "-o", "allow_other", "--endpoint", geesefs.endpoint}, args...)
+	glog.Info("Starting geesefs using systemd: " + strings.Join(args, " "))
+	unitName := "geesefs-" + systemd.PathBusEscape(volumeID) + ".service"
 	newProps := []systemd.Property{
 		systemd.Property{
-			Name: "Description",
-			Value: dbus.MakeVariant("GeeseFS mount for Kubernetes volume "+volumeID),
+			Name:  "Description",
+			Value: dbus.MakeVariant("GeeseFS mount for Kubernetes volume " + volumeID),
 		},
 		systemd.PropExecStart(args, false),
 		systemd.Property{
-			Name: "Environment",
-			Value: dbus.MakeVariant([]string{ "AWS_ACCESS_KEY_ID="+geesefs.accessKeyID, "AWS_SECRET_ACCESS_KEY="+geesefs.secretAccessKey }),
+			Name:  "Environment",
+			Value: dbus.MakeVariant([]string{"AWS_ACCESS_KEY_ID=" + geesefs.accessKeyID, "AWS_SECRET_ACCESS_KEY=" + geesefs.secretAccessKey}),
 		},
 		systemd.Property{
-			Name: "CollectMode",
+			Name:  "CollectMode",
 			Value: dbus.MakeVariant("inactive-or-failed"),
 		},
 	}
@@ -178,7 +189,7 @@ func (geesefs *geesefsMounter) Mount(target, volumeID string) error {
 				// FIXME This may mean that the same bucket&path are used for multiple PVs. Support it somehow
 				return fmt.Errorf(
 					"GeeseFS for volume %v is already mounted on host, but"+
-					" in a different directory. We want %v, but it's in %v",
+						" in a different directory. We want %v, but it's in %v",
 					volumeID, target, curPath,
 				)
 			}

--- a/pkg/s3/client.go
+++ b/pkg/s3/client.go
@@ -33,6 +33,7 @@ type Config struct {
 	Endpoint        string
 	Mounter         string
 	Insecure        bool
+	Minio           string
 }
 
 type FSMeta struct {
@@ -64,10 +65,8 @@ func NewClient(cfg *Config) (*s3Client, error) {
 		transport.TLSClientConfig = tlsConfig
 	}
 	minioClient, err := minio.New(endpoint, &minio.Options{
-		Transport: transport,
-		Creds:     credentials.NewStaticV4(client.Config.AccessKeyID, client.Config.SecretAccessKey, ""),
-		Region:    client.Config.Region,
-		Secure:    ssl,
+		Creds:  credentials.NewStaticV4(client.Config.AccessKeyID, client.Config.SecretAccessKey, ""),
+		Secure: ssl,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
"Hello @vitalif, I've found that when MinIO and CSI are in the same cluster, and there's no external domain name, using systemd's GeeseFS prevents the connection through Kubernetes' service-ClusterIP. In the case of using systemd, a connection to the NodePort of the MinIO-service is mandatory.
﻿
Based on the above description, I've made some code modifications. I would appreciate it if you could review them."