### PR TITLE
added create configmap for custom CA

### DIFF
--- a/deploy/helm/csi-s3/README.md
+++ b/deploy/helm/csi-s3/README.md
@@ -39,3 +39,7 @@ The following table lists all configuration parameters and their default values.
 | `tolerations.all`            | Tolerate all taints by the CSI-S3 node driver (mounter)                | false                                                  |
 | `tolerations.node`           | Custom tolerations for the CSI-S3 node driver (mounter)                | []                                                     |
 | `tolerations.controller`     | Custom tolerations for the CSI-S3 controller (provisioner)             | []                                                     |
+| `ca.create`                  | Create configmap for custom CA cert                                    | false                                                  |
+| `ca.name`                    | Configmap name for custom CA cert                                      | ca-custom-pemstore                                     |
+| `ca.path`                    | Configmap path for custom CA cert                                      | ca-custom-cert.pem                                     |
+| `ca.certificate`             | Configmap string data CA                                               |                                                        |

--- a/deploy/helm/csi-s3/templates/ca-config-map.yaml
+++ b/deploy/helm/csi-s3/templates/ca-config-map.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.ca.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.ca.name }}
+  namespace: {{ .Release.Namespace }}
+data:
+  {{ .Values.ca.path }}: |-
+    {{ .Values.ca.certificate | nindent 4 }}
+{{- end }}

--- a/deploy/helm/csi-s3/templates/csi-s3.yaml
+++ b/deploy/helm/csi-s3/templates/csi-s3.yaml
@@ -71,6 +71,12 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration/
+            {{- if and .Values.ca.create .Values.ca.name .Values.ca.path }}
+            - name: {{ .Values.ca.name}}
+              mountPath: /etc/ssl/certs/{{ .Values.ca.path }}
+              subPath: {{ .Values.ca.path }}
+              readOnly: false
+            {{- end }}
         - name: csi-s3
           securityContext:
             privileged: true
@@ -103,6 +109,12 @@ spec:
               mountPath: /dev/fuse
             - name: systemd-control
               mountPath: /run/systemd
+            {{- if and .Values.ca.create .Values.ca.name .Values.ca.path }}
+            - name: {{ .Values.ca.name}}
+              mountPath: /etc/ssl/certs/{{ .Values.ca.path }}
+              subPath: {{ .Values.ca.path }}
+              readOnly: false
+            {{- end }}
       volumes:
         - name: registration-dir
           hostPath:
@@ -127,3 +139,8 @@ spec:
           hostPath:
             path: /run/systemd
             type: DirectoryOrCreate
+        {{- if and .Values.ca.create .Values.ca.name }}
+        - name: {{ .Values.ca.name }}
+          configMap:
+            name: {{ .Values.ca.name }}
+        {{- end }}

--- a/deploy/helm/csi-s3/templates/provisioner.yaml
+++ b/deploy/helm/csi-s3/templates/provisioner.yaml
@@ -94,6 +94,12 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi
+          {{- if and .Values.ca.create .Values.ca.name .Values.ca.path }}
+            - name: {{ .Values.ca.name}}
+              mountPath: /etc/ssl/certs/{{ .Values.ca.path }}
+              subPath: {{ .Values.ca.path }}
+              readOnly: false
+          {{- end }}
         - name: csi-s3
           image: {{ .Values.images.csi }}
           imagePullPolicy: IfNotPresent
@@ -111,6 +117,17 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi
+          {{- if and .Values.ca.create .Values.ca.name .Values.ca.path }}
+            - name: {{ .Values.ca.name}}
+              mountPath: /etc/ssl/certs/{{ .Values.ca.path }}
+              subPath: {{ .Values.ca.path }}
+              readOnly: false
+          {{- end }}
       volumes:
         - name: socket-dir
           emptyDir: {}
+      {{- if and .Values.ca.create .Values.ca.name }}
+        - name: {{ .Values.ca.name }}
+          configMap:
+            name: {{ .Values.ca.name }}
+      {{- end }}

--- a/deploy/helm/csi-s3/values.yaml
+++ b/deploy/helm/csi-s3/values.yaml
@@ -48,3 +48,12 @@ tolerations:
 nodeSelector: {}
 
 kubeletPath: /var/lib/kubelet
+
+ca:
+  create: false
+  name: ca-custom-pemstore
+  path: ca-custom-cert.pem
+  certificate: ""  #|
+    # -----BEGIN CERTIFICATE-----
+    # ...
+    # -----END CERTIFICATE-----


### PR DESCRIPTION
Добавлено создание ConfigMap в helm/templates для личного CA сертификата. Это позволит добавлять CA от своего локального minio и избежать ошибок x509 certificate signed by unknown authority