### PR TITLE
:sparkles: (provisioner) added extraArgs to values.yaml to pass arguments to provisioner container

### DIFF
--- a/deploy/helm/csi-s3/README.md
+++ b/deploy/helm/csi-s3/README.md
@@ -23,6 +23,7 @@ The following table lists all configuration parameters and their default values.
 
 | Parameter                    | Description                                                            | Default                                                |
 | ---------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------ |
+| `provisioner.extraArgs`      | Extra arguments for the provisioner                                    | []                                                   |
 | `storageClass.create`        | Specifies whether the storage class should be created                  | true                                                   |
 | `storageClass.name`          | Storage class name                                                     | csi-s3                                                 |
 | `storageClass.singleBucket`  | Use a single bucket for all dynamically provisioned persistent volumes |                                                        |

--- a/deploy/helm/csi-s3/manifest.yaml
+++ b/deploy/helm/csi-s3/manifest.yaml
@@ -8,6 +8,15 @@ images:
   - full: images.provisioner
   - full: images.csi
 user_values:
+  - name: provisioner.extraArgs
+    title:
+      en: Extra arguments for the provisioner
+      ru: Дополнительные аргументы для провиженера
+    description:
+      en: Extra arguments to pass to the provisioner container
+      ru: Дополнительные аргументы, которые будут переданы в контейнер провиженера.
+    string_value:
+      default_value: ""
   - name: storageClass.create
     title:
       en: Create storage class

--- a/deploy/helm/csi-s3/templates/provisioner.yaml
+++ b/deploy/helm/csi-s3/templates/provisioner.yaml
@@ -87,6 +87,9 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=4"
+          {{- range .Values.provisioner.extraArgs }}
+            - {{ . | quote }}
+          {{- end }}
           env:
             - name: ADDRESS
               value: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi/csi.sock

--- a/deploy/helm/csi-s3/values.yaml
+++ b/deploy/helm/csi-s3/values.yaml
@@ -7,6 +7,13 @@ images:
   # Main image
   csi: cr.yandex/crp9ftr22d26age3hulg/yandex-cloud/csi-s3/csi-s3-driver:0.43.7
 
+provisioner:
+  # Extra arguments for the provisioner
+  # Example - change the bucket name prefix from "pvc" to "pvc-s3":
+  # extraArgs:
+  #   - "--volume-name-prefix=pvc-s3"
+  extraArgs: []
+
 storageClass:
   # Specifies whether the storage class should be created
   create: true


### PR DESCRIPTION
Hello @vitalif ,

This feature adds the possibility to modify from the Helm chart `values.yaml` the provisioner args available here:

https://github.com/kubernetes-csi/external-provisioner#command-line-options

In my use case, we have 3 envs (dev, preprod, prod) and wish to separate bucket using prefix change therefore exposing the provisioner args is necessary.

Best regards.