### PR TITLE
change registry for csi-node-driver-registrar in csi-s3.yaml

### DIFF
--- a/deploy/kubernetes/csi-s3.yaml
+++ b/deploy/kubernetes/csi-s3.yaml
@@ -45,7 +45,7 @@ spec:
       serviceAccount: csi-s3
       containers:
         - name: driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.2.0
           args:
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
             - "--v=4"


### PR DESCRIPTION
change registry for csi-node-driver-registrar in csi-s3.yaml

quay.io/k8scsi/csi-node-driver-registrar:v1.2.0 was returning unexpected status from HEAD request to https://quay.io/v2/k8scsi/csi-node-driver-registrar/manifests/v1.2.0: 401 UNAUTHORIZED