### PR TITLE
Fix error message to use correct variable

### DIFF
--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -75,7 +75,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	exists, err := client.BucketExists(bucketName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check if bucket %s exists: %v", volumeID, err)
+		return nil, fmt.Errorf("failed to check if bucket %s exists: %v", bucketName, err)
 	}
 
 	if !exists {


### PR DESCRIPTION
- since `bucketName` is actually what is being checked it doesn't make sense to log out the `volumeID`