### PR TITLE
Handle missing /dev/fuse by creating it dynamically in initContainer

### DIFF
--- a/deploy/kubernetes/csi-s3.yaml
+++ b/deploy/kubernetes/csi-s3.yaml
@@ -43,6 +43,29 @@ spec:
           effect: NoExecute
           tolerationSeconds: 300
       serviceAccount: csi-s3
+      initContainers:
+        - name: setup-fuse-device
+          image: alpine:3.22
+          securityContext:
+            privileged: true
+          command:
+            - sh
+            - -c
+            - |
+              set -eux
+              if [ -d /dev/fuse ]; then
+                echo "/dev/fuse is a directory, removing..."
+                rm -rf /dev/fuse
+              fi
+              if [ ! -e /dev/fuse ]; then
+                echo "Creating /dev/fuse..."
+                mknod /dev/fuse c 10 229
+                chmod 666 /dev/fuse
+              fi
+              ls -l /dev/fuse
+          volumeMounts:
+            - name: dev
+              mountPath: /dev
       containers:
         - name: driver-registrar
           image: cr.yandex/crp9ftr22d26age3hulg/yandex-cloud/csi-s3/csi-node-driver-registrar:v1.2.0
@@ -113,9 +136,16 @@ spec:
           hostPath:
             path: /var/lib/kubelet/pods
             type: Directory
+        - name: dev
+          hostPath:
+            path: /dev
+            type: Directory
         - name: fuse-device
           hostPath:
             path: /dev/fuse
+            # Since it may not exist, we’ll specify it as a string first.
+            # In that case, it will be created as a directory, so we’ll convert it to a character device (CharDevice) in the initContainer to make it available for use in the subsequent containers.
+            # type: CharDevice
         - name: systemd-control
           hostPath:
             path: /run/systemd


### PR DESCRIPTION
First of all, thank you very much for creating a great project.

## Description

This PR adds logic to handle environments where `/dev/fuse` does not exist by default.
When `/dev/fuse` is missing, it will initially be created as a directory.
Then, during the initContainer phase, it will be converted into a character device so that the main container can use it properly.

## Details

- Added `/dev` volume mount and handling logic.
- Introduced an initContainer to ensure `/dev/fuse` is correctly created as a `CharDevice`.

## Why

In some environments (e.g., Alpine-based images ...etc), `/dev/fuse` is not provided by default.
As a result, after applying the current manifest and deploying the Pod, the following error occurs.

```
csi-s3-ctl2w csi-s3 /bin/fusermount: failed to open /dev/fuse: Is a directory
csi-s3-ctl2w csi-s3 2025/11/07 09:24:03.128866 main.FATAL Mounting file system: Mount: mount: running /bin/fusermount: exit status 1
csi-s3-ctl2w csi-s3 E1107 09:24:04.136909       1 utils.go:101] GRPC error: Error fuseMount command: geesefs
```
This happens because `/dev/fuse` does not exist and is therefore created as a directory, causing the Pod to remain in the `Pending` state and fail to transition to `Running`.