### PR TITLE
upgrade registrar and provisioner images

### DIFF
--- a/deploy/helm/csi-s3/values.yaml
+++ b/deploy/helm/csi-s3/values.yaml
@@ -1,9 +1,9 @@
 ---
 images:
-  # Source: quay.io/k8scsi/csi-node-driver-registrar:v2.16.0
-  registrar: cr.yandex/crp9ftr22d26age3hulg/yandex-cloud/csi-s3/csi-node-driver-registrar:v2.16.0
-  # Source: quay.io/k8scsi/csi-provisioner:v6.2.0
-  provisioner: cr.yandex/crp9ftr22d26age3hulg/yandex-cloud/csi-s3/csi-provisioner:v6.2.0
+  # Source: https://github.com/kubernetes-csi/node-driver-registrar
+  registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
+  # Source: https://github.com/kubernetes-csi/external-provisioner
+  provisioner: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
   # Main image
   csi: cr.yandex/crp9ftr22d26age3hulg/yandex-cloud/csi-s3/csi-s3-driver:0.43.7
 

--- a/deploy/kubernetes/csi-s3.yaml
+++ b/deploy/kubernetes/csi-s3.yaml
@@ -45,7 +45,7 @@ spec:
       serviceAccount: csi-s3
       containers:
         - name: driver-registrar
-          image: cr.yandex/crp9ftr22d26age3hulg/yandex-cloud/csi-s3/csi-node-driver-registrar:v2.16.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
           args:
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
             - "--v=4"

--- a/deploy/kubernetes/provisioner.yaml
+++ b/deploy/kubernetes/provisioner.yaml
@@ -76,7 +76,7 @@ spec:
           operator: Exists
       containers:
         - name: csi-provisioner
-          image: cr.yandex/crp9ftr22d26age3hulg/yandex-cloud/csi-s3/csi-provisioner:v6.2.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=4"


### PR DESCRIPTION
- tested on k8s 1.33.1 and working as expected
- there does not seem to be any good reason for pulling k8s from some random yandex image registry

closes #164 