### PR TITLE
chore(chart): add initContainers and volumes

### DIFF
--- a/deploy/helm/csi-s3/README.md
+++ b/deploy/helm/csi-s3/README.md
@@ -21,21 +21,36 @@ to your [Yandex Object Storage](https://cloud.yandex.com/en-ru/services/storage)
 
 The following table lists all configuration parameters and their default values.
 
-| Parameter                    | Description                                                            | Default                                                |
-| ---------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------ |
-| `storageClass.create`        | Specifies whether the storage class should be created                  | true                                                   |
-| `storageClass.name`          | Storage class name                                                     | csi-s3                                                 |
-| `storageClass.singleBucket`  | Use a single bucket for all dynamically provisioned persistent volumes |                                                        |
-| `storageClass.mounter`       | Mounter to use. Either geesefs, s3fs or rclone. geesefs recommended    | geesefs                                                |
-| `storageClass.mountOptions`  | GeeseFS mount options                                                  | `--memory-limit 1000 --dir-mode 0777 --file-mode 0666` |
-| `storageClass.reclaimPolicy` | Volume reclaim policy                                                  | Delete                                                 |
-| `storageClass.annotations`   | Annotations for the storage class                                      |                                                        |
-| `secret.create`              | Specifies whether the secret should be created                         | true                                                   |
-| `secret.name`                | Name of the secret                                                     | csi-s3-secret                                          |
-| `secret.accessKey`           | S3 Access Key                                                          |                                                        |
-| `secret.secretKey`           | S3 Secret Key                                                          |                                                        |
-| `secret.endpoint`            | Endpoint                                                               | https://storage.yandexcloud.net                        |
-| `secret.region`              | Region                                                                 |                         |
-| `tolerations.all`            | Tolerate all taints by the CSI-S3 node driver (mounter)                | false                                                  |
-| `tolerations.node`           | Custom tolerations for the CSI-S3 node driver (mounter)                | []                                                     |
-| `tolerations.controller`     | Custom tolerations for the CSI-S3 controller (provisioner)             | []                                                     |
+| Parameter                           | Description                                                            | Default                                                |
+| ----------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------ |
+| `storageClass.create`               | Specifies whether the storage class should be created                  | true                                                   |
+| `storageClass.name`                 | Storage class name                                                     | csi-s3                                                 |
+| `storageClass.singleBucket`         | Use a single bucket for all dynamically provisioned persistent volumes |                                                        |
+| `storageClass.mounter`              | Mounter to use. Either geesefs, s3fs or rclone. geesefs recommended    | geesefs                                                |
+| `storageClass.mountOptions`         | GeeseFS mount options                                                  | `--memory-limit 1000 --dir-mode 0777 --file-mode 0666` |
+| `storageClass.reclaimPolicy`        | Volume reclaim policy                                                  | Delete                                                 |
+| `storageClass.annotations`          | Annotations for the storage class                                      |                                                        |
+| `secret.create`                     | Specifies whether the secret should be created                         | true                                                   |
+| `secret.name`                       | Name of the secret                                                     | csi-s3-secret                                          |
+| `secret.accessKey`                  | S3 Access Key                                                          |                                                        |
+| `secret.secretKey`                  | S3 Secret Key                                                          |                                                        |
+| `secret.endpoint`                   | Endpoint                                                               | https://storage.yandexcloud.net                        |
+| `secret.region`                     | Region                                                                 |                                                        |
+| `tolerations.all`                   | Tolerate all taints by the CSI-S3 node driver (mounter)                | false                                                  |
+| `tolerations.node`                  | Custom tolerations for the CSI-S3 node driver (mounter)                | []                                                     |
+| `tolerations.controller`            | Custom tolerations for the CSI-S3 controller (provisioner)             | []                                                     |
+| `initContainer.enabled`             | Enable init container for node daemon set                              | false                                                  |
+| `initContainer.image`               | Init container image for node daemon set                               |                                                        |
+| `initContainer.imagePullPolicy`     | Init container image pull policy for node daemon set                   | IfNotPresent                                           |
+| `initContainer.command`             | Init container command for node daemon set                             | []                                                     |
+| `initContainer.args`                | Init container args for node daemon set                                | []                                                     |
+| `initContainer.volumeMounts`        | Init container volume mounts for node daemon set                       |                                                        |
+| `initContainerProvisioner.enabled`  | Enable init container for provisioner stateful set                     | false                                                  |
+| `initContainerProvisioner.image`    | Init container image for provisioner stateful set                      |                                                        |
+| `initContainerProvisioner.imagePullPolicy` | Init container image pull policy for provisioner           | IfNotPresent                                           |
+| `initContainerProvisioner.command`  | Init container command for provisioner stateful set                    | []                                                     |
+| `initContainerProvisioner.args`     | Init container args for provisioner stateful set                       | []                                                     |
+| `initContainerProvisioner.volumeMounts` | Init container volume mounts for provisioner                       |                                                        |
+| `extraVolumes`                      | Extra volumes to mount on all containers                               | []                                                     |
+| `extraVolumeMounts`                 | Extra volume mounts for node daemon set containers                     | []                                                     |
+| `extraVolumeMountsProvisioner`      | Extra volume mounts for provisioner stateful set containers            | []                                                     |

--- a/deploy/helm/csi-s3/templates/csi-s3.yaml
+++ b/deploy/helm/csi-s3/templates/csi-s3.yaml
@@ -50,6 +50,24 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       serviceAccount: csi-s3
+      {{- if .Values.initContainer.enabled }}
+      initContainers:
+        - name: init-container
+          image: {{ .Values.initContainer.image }}
+          imagePullPolicy: {{ .Values.initContainer.imagePullPolicy }}
+          {{- with .Values.initContainer.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.initContainer.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.initContainer.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- end }}
       containers:
         - name: driver-registrar
           image: {{ .Values.images.registrar }}
@@ -71,6 +89,9 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration/
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         - name: csi-s3
           securityContext:
             privileged: true
@@ -103,6 +124,9 @@ spec:
               mountPath: /dev/fuse
             - name: systemd-control
               mountPath: /run/systemd
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: registration-dir
           hostPath:
@@ -127,3 +151,6 @@ spec:
           hostPath:
             path: /run/systemd
             type: DirectoryOrCreate
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/deploy/helm/csi-s3/templates/provisioner.yaml
+++ b/deploy/helm/csi-s3/templates/provisioner.yaml
@@ -81,6 +81,24 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.initContainerProvisioner.enabled }}
+      initContainers:
+        - name: init-container
+          image: {{ .Values.initContainerProvisioner.image }}
+          imagePullPolicy: {{ .Values.initContainerProvisioner.imagePullPolicy }}
+          {{- with .Values.initContainerProvisioner.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.initContainerProvisioner.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.initContainerProvisioner.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- end }}
       containers:
         - name: csi-provisioner
           image: {{ .Values.images.provisioner }}
@@ -94,6 +112,9 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi
+            {{- with .Values.extraVolumeMountsProvisioner }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         - name: csi-s3
           image: {{ .Values.images.csi }}
           imagePullPolicy: IfNotPresent
@@ -111,6 +132,12 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi
+            {{- with .Values.extraVolumeMountsProvisioner }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: socket-dir
           emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/deploy/helm/csi-s3/values.yaml
+++ b/deploy/helm/csi-s3/values.yaml
@@ -48,3 +48,41 @@ tolerations:
 nodeSelector: {}
 
 kubeletPath: /var/lib/kubelet
+
+# Init container for node daemon set (optional)
+initContainer:
+  enabled: false
+  image: ""
+  imagePullPolicy: IfNotPresent
+  command: []
+  args: []
+  # volumeMounts: []
+
+# Init container for provisioner stateful set (optional)
+initContainerProvisioner:
+  enabled: false
+  image: ""
+  imagePullPolicy: IfNotPresent
+  command: []
+  args: []
+  # volumeMounts: []
+
+# Extra volumes to mount on all containers
+extraVolumes: []
+# Example:
+# - name: my-volume
+#   hostPath:
+#     path: /some/path
+#     type: Directory
+
+# Extra volume mounts for node daemon set containers
+extraVolumeMounts: []
+# Example:
+# - name: my-volume
+#   mountPath: /mnt/my-volume
+
+# Extra volume mounts for provisioner stateful set containers
+extraVolumeMountsProvisioner: []
+# Example:
+# - name: my-volume
+#   mountPath: /mnt/my-volume


### PR DESCRIPTION
### Summary

This PR enables loading custom CAs into the truststore via a mounted volume (e.g., from Vault) and an init container.

### Why

Internal services use TLS certificates signed by private CAs not included in the default truststore. Without them, SSL connections fail.

### Changes

Adds a volume mount for custom CA certificates.

Adds an init container that imports these certificates into the truststore before the main application starts.

### Benefit

Supports internal/private TLS endpoints without rebuilding images.

Makes certificate management dynamic and environment-agnostic.