### PR TITLE
Add IRSA authentication support

### DIFF
--- a/deploy/helm/csi-s3/templates/secret.yaml
+++ b/deploy/helm/csi-s3/templates/secret.yaml
@@ -15,4 +15,13 @@ stringData:
 {{- if .Values.secret.region }}
   region: {{ .Values.secret.region }}
 {{- end }}
+{{- if .Values.secret.useIRSA }}
+  useIRSA: "true"
+{{- end }}
+{{- if .Values.secret.roleArn }}
+  roleArn: {{ .Values.secret.roleArn }}
+{{- end }}
+{{- if .Values.secret.webIdentityTokenFile }}
+  webIdentityTokenFile: {{ .Values.secret.webIdentityTokenFile }}
+{{- end }}
 {{- end -}}

--- a/deploy/helm/csi-s3/values.yaml
+++ b/deploy/helm/csi-s3/values.yaml
@@ -31,14 +31,20 @@ secret:
   create: true
   # Name of the secret
   name: csi-s3-secret
-  # S3 Access Key
+  # S3 Access Key (not required when using IRSA)
   accessKey: ""
-  # S3 Secret Key
+  # S3 Secret Key (not required when using IRSA)
   secretKey: ""
   # Endpoint
   endpoint: https://storage.yandexcloud.net
   # Region
   region: ""
+  # Use IRSA (IAM Roles for Service Accounts) for authentication instead of static credentials
+  useIRSA: false
+  # IAM role ARN (optional, defaults to AWS_ROLE_ARN env var injected by EKS)
+  roleArn: ""
+  # Path to the projected service account token file (optional, defaults to EKS-injected path)
+  webIdentityTokenFile: ""
 
 tolerations:
   all: false

--- a/deploy/kubernetes/examples/secret.yaml
+++ b/deploy/kubernetes/examples/secret.yaml
@@ -10,3 +10,9 @@ stringData:
   endpoint: https://storage.yandexcloud.net
   # For AWS set it to AWS region
   #region: ""
+  # To use IRSA (IAM Roles for Service Accounts) instead of static credentials,
+  # set useIRSA to "true" and remove accessKeyID/secretAccessKey:
+  #useIRSA: "true"
+  # Optional: override the role ARN and token file path (defaults to EKS-injected env vars)
+  #roleArn: "arn:aws:iam::123456789012:role/my-s3-role"
+  #webIdentityTokenFile: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"

--- a/pkg/mounter/geesefs.go
+++ b/pkg/mounter/geesefs.go
@@ -19,20 +19,26 @@ const (
 
 // Implements Mounter
 type geesefsMounter struct {
-	meta            *s3.FSMeta
-	endpoint        string
-	region          string
-	accessKeyID     string
-	secretAccessKey string
+	meta                 *s3.FSMeta
+	endpoint             string
+	region               string
+	accessKeyID          string
+	secretAccessKey      string
+	useIRSA              bool
+	roleArn              string
+	webIdentityTokenFile string
 }
 
 func newGeeseFSMounter(meta *s3.FSMeta, cfg *s3.Config) (Mounter, error) {
 	return &geesefsMounter{
-		meta:            meta,
-		endpoint:        cfg.Endpoint,
-		region:          cfg.Region,
-		accessKeyID:     cfg.AccessKeyID,
-		secretAccessKey: cfg.SecretAccessKey,
+		meta:                 meta,
+		endpoint:             cfg.Endpoint,
+		region:               cfg.Region,
+		accessKeyID:          cfg.AccessKeyID,
+		secretAccessKey:      cfg.SecretAccessKey,
+		useIRSA:              cfg.UseIRSA,
+		roleArn:              cfg.RoleArn,
+		webIdentityTokenFile: cfg.WebIdentityTokenFile,
 	}, nil
 }
 
@@ -69,17 +75,30 @@ func (geesefs *geesefsMounter) CopyBinary(from, to string) error {
 	return nil
 }
 
+func (geesefs *geesefsMounter) authEnvs() []string {
+	if geesefs.useIRSA {
+		envs := []string{}
+		if geesefs.roleArn != "" {
+			envs = append(envs, "AWS_ROLE_ARN="+geesefs.roleArn)
+		}
+		if geesefs.webIdentityTokenFile != "" {
+			envs = append(envs, "AWS_WEB_IDENTITY_TOKEN_FILE="+geesefs.webIdentityTokenFile)
+		}
+		return envs
+	}
+	return []string{
+		"AWS_ACCESS_KEY_ID=" + geesefs.accessKeyID,
+		"AWS_SECRET_ACCESS_KEY=" + geesefs.secretAccessKey,
+	}
+}
+
 func (geesefs *geesefsMounter) MountDirect(target string, args []string) error {
 	args = append([]string{
 		"--endpoint", geesefs.endpoint,
 		"-o", "allow_other",
 		"--log-file", "/dev/stderr",
 	}, args...)
-	envs := []string{
-		"AWS_ACCESS_KEY_ID=" + geesefs.accessKeyID,
-		"AWS_SECRET_ACCESS_KEY=" + geesefs.secretAccessKey,
-	}
-	return fuseMount(target, geesefsCmd, args, envs)
+	return fuseMount(target, geesefsCmd, args, geesefs.authEnvs())
 }
 
 type execCmd struct {
@@ -164,7 +183,7 @@ func (geesefs *geesefsMounter) Mount(target, volumeID string) error {
 		systemd.PropExecStart(args, false),
 		systemd.Property{
 			Name: "Environment",
-			Value: dbus.MakeVariant([]string{ "AWS_ACCESS_KEY_ID="+geesefs.accessKeyID, "AWS_SECRET_ACCESS_KEY="+geesefs.secretAccessKey }),
+			Value: dbus.MakeVariant(geesefs.authEnvs()),
 		},
 		systemd.Property{
 			Name: "CollectMode",

--- a/pkg/mounter/mounter_test.go
+++ b/pkg/mounter/mounter_test.go
@@ -1,0 +1,118 @@
+package mounter
+
+import (
+	"testing"
+
+	"github.com/yandex-cloud/k8s-csi-s3/pkg/s3"
+)
+
+func TestGeeseFSAuthEnvs_StaticCreds(t *testing.T) {
+	m := &geesefsMounter{
+		accessKeyID:     "AKID",
+		secretAccessKey: "SECRET",
+		useIRSA:         false,
+	}
+	envs := m.authEnvs()
+	if len(envs) != 2 {
+		t.Fatalf("expected 2 env vars, got %d", len(envs))
+	}
+	if envs[0] != "AWS_ACCESS_KEY_ID=AKID" {
+		t.Errorf("unexpected env[0]: %s", envs[0])
+	}
+	if envs[1] != "AWS_SECRET_ACCESS_KEY=SECRET" {
+		t.Errorf("unexpected env[1]: %s", envs[1])
+	}
+}
+
+func TestGeeseFSAuthEnvs_IRSA(t *testing.T) {
+	m := &geesefsMounter{
+		useIRSA:              true,
+		roleArn:              "arn:aws:iam::123456789012:role/test",
+		webIdentityTokenFile: "/var/run/secrets/token",
+	}
+	envs := m.authEnvs()
+	if len(envs) != 2 {
+		t.Fatalf("expected 2 env vars, got %d", len(envs))
+	}
+	if envs[0] != "AWS_ROLE_ARN=arn:aws:iam::123456789012:role/test" {
+		t.Errorf("unexpected env[0]: %s", envs[0])
+	}
+	if envs[1] != "AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/token" {
+		t.Errorf("unexpected env[1]: %s", envs[1])
+	}
+}
+
+func TestGeeseFSAuthEnvs_IRSAFromEnv(t *testing.T) {
+	// When roleArn/tokenFile are empty, IRSA relies on pod-injected env vars.
+	// The mounter should pass no extra env vars (the process inherits them).
+	m := &geesefsMounter{
+		useIRSA: true,
+	}
+	envs := m.authEnvs()
+	if len(envs) != 0 {
+		t.Fatalf("expected 0 env vars when IRSA fields are empty, got %d: %v", len(envs), envs)
+	}
+}
+
+func TestNewGeeseFSMounter_IRSA(t *testing.T) {
+	meta := &s3.FSMeta{BucketName: "test-bucket"}
+	cfg := &s3.Config{
+		Endpoint:             "https://s3.amazonaws.com",
+		Region:               "us-east-1",
+		UseIRSA:              true,
+		RoleArn:              "arn:aws:iam::123456789012:role/test",
+		WebIdentityTokenFile: "/var/run/secrets/token",
+	}
+	m, err := newGeeseFSMounter(meta, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	gm := m.(*geesefsMounter)
+	if !gm.useIRSA {
+		t.Error("expected useIRSA=true")
+	}
+	if gm.roleArn != cfg.RoleArn {
+		t.Errorf("unexpected roleArn: %s", gm.roleArn)
+	}
+}
+
+func TestNewRcloneMounter_IRSA(t *testing.T) {
+	meta := &s3.FSMeta{BucketName: "test-bucket"}
+	cfg := &s3.Config{
+		Endpoint:             "https://s3.amazonaws.com",
+		Region:               "us-east-1",
+		UseIRSA:              true,
+		RoleArn:              "arn:aws:iam::123456789012:role/test",
+		WebIdentityTokenFile: "/var/run/secrets/token",
+	}
+	m, err := newRcloneMounter(meta, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rm := m.(*rcloneMounter)
+	if !rm.useIRSA {
+		t.Error("expected useIRSA=true")
+	}
+}
+
+func TestNewS3fsMounter_IRSA(t *testing.T) {
+	meta := &s3.FSMeta{BucketName: "test-bucket"}
+	cfg := &s3.Config{
+		Endpoint:             "https://s3.amazonaws.com",
+		Region:               "us-east-1",
+		UseIRSA:              true,
+		RoleArn:              "arn:aws:iam::123456789012:role/test",
+		WebIdentityTokenFile: "/var/run/secrets/token",
+	}
+	m, err := newS3fsMounter(meta, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sm := m.(*s3fsMounter)
+	if !sm.useIRSA {
+		t.Error("expected useIRSA=true")
+	}
+	if sm.pwFileContent != ":" {
+		t.Errorf("expected empty pw content for IRSA, got %s", sm.pwFileContent)
+	}
+}

--- a/pkg/mounter/rclone.go
+++ b/pkg/mounter/rclone.go
@@ -9,11 +9,14 @@ import (
 
 // Implements Mounter
 type rcloneMounter struct {
-	meta            *s3.FSMeta
-	url             string
-	region          string
-	accessKeyID     string
-	secretAccessKey string
+	meta                 *s3.FSMeta
+	url                  string
+	region               string
+	accessKeyID          string
+	secretAccessKey      string
+	useIRSA              bool
+	roleArn              string
+	webIdentityTokenFile string
 }
 
 const (
@@ -22,11 +25,14 @@ const (
 
 func newRcloneMounter(meta *s3.FSMeta, cfg *s3.Config) (Mounter, error) {
 	return &rcloneMounter{
-		meta:            meta,
-		url:             cfg.Endpoint,
-		region:          cfg.Region,
-		accessKeyID:     cfg.AccessKeyID,
-		secretAccessKey: cfg.SecretAccessKey,
+		meta:                 meta,
+		url:                  cfg.Endpoint,
+		region:               cfg.Region,
+		accessKeyID:          cfg.AccessKeyID,
+		secretAccessKey:      cfg.SecretAccessKey,
+		useIRSA:              cfg.UseIRSA,
+		roleArn:              cfg.RoleArn,
+		webIdentityTokenFile: cfg.WebIdentityTokenFile,
 	}, nil
 }
 
@@ -46,9 +52,19 @@ func (rclone *rcloneMounter) Mount(target, volumeID string) error {
 		args = append(args, fmt.Sprintf("--s3-region=%s", rclone.region))
 	}
 	args = append(args, rclone.meta.MountOptions...)
-	envs := []string{
-		"AWS_ACCESS_KEY_ID=" + rclone.accessKeyID,
-		"AWS_SECRET_ACCESS_KEY=" + rclone.secretAccessKey,
+	var envs []string
+	if rclone.useIRSA {
+		if rclone.roleArn != "" {
+			envs = append(envs, "AWS_ROLE_ARN="+rclone.roleArn)
+		}
+		if rclone.webIdentityTokenFile != "" {
+			envs = append(envs, "AWS_WEB_IDENTITY_TOKEN_FILE="+rclone.webIdentityTokenFile)
+		}
+	} else {
+		envs = []string{
+			"AWS_ACCESS_KEY_ID=" + rclone.accessKeyID,
+			"AWS_SECRET_ACCESS_KEY=" + rclone.secretAccessKey,
+		}
 	}
 	return fuseMount(target, rcloneCmd, args, envs)
 }

--- a/pkg/mounter/s3fs.go
+++ b/pkg/mounter/s3fs.go
@@ -9,10 +9,13 @@ import (
 
 // Implements Mounter
 type s3fsMounter struct {
-	meta          *s3.FSMeta
-	url           string
-	region        string
-	pwFileContent string
+	meta                 *s3.FSMeta
+	url                  string
+	region               string
+	pwFileContent        string
+	useIRSA              bool
+	roleArn              string
+	webIdentityTokenFile string
 }
 
 const (
@@ -21,16 +24,30 @@ const (
 
 func newS3fsMounter(meta *s3.FSMeta, cfg *s3.Config) (Mounter, error) {
 	return &s3fsMounter{
-		meta:          meta,
-		url:           cfg.Endpoint,
-		region:        cfg.Region,
-		pwFileContent: cfg.AccessKeyID + ":" + cfg.SecretAccessKey,
+		meta:                 meta,
+		url:                  cfg.Endpoint,
+		region:               cfg.Region,
+		pwFileContent:        cfg.AccessKeyID + ":" + cfg.SecretAccessKey,
+		useIRSA:              cfg.UseIRSA,
+		roleArn:              cfg.RoleArn,
+		webIdentityTokenFile: cfg.WebIdentityTokenFile,
 	}, nil
 }
 
 func (s3fs *s3fsMounter) Mount(target, volumeID string) error {
-	if err := writes3fsPass(s3fs.pwFileContent); err != nil {
-		return err
+	var envs []string
+	if s3fs.useIRSA {
+		// s3fs supports IAM role auth; skip password file
+		if s3fs.roleArn != "" {
+			envs = append(envs, "AWS_ROLE_ARN="+s3fs.roleArn)
+		}
+		if s3fs.webIdentityTokenFile != "" {
+			envs = append(envs, "AWS_WEB_IDENTITY_TOKEN_FILE="+s3fs.webIdentityTokenFile)
+		}
+	} else {
+		if err := writes3fsPass(s3fs.pwFileContent); err != nil {
+			return err
+		}
 	}
 	args := []string{
 		fmt.Sprintf("%s:/%s", s3fs.meta.BucketName, s3fs.meta.Prefix),
@@ -40,11 +57,14 @@ func (s3fs *s3fsMounter) Mount(target, volumeID string) error {
 		"-o", "allow_other",
 		"-o", "mp_umask=000",
 	}
+	if s3fs.useIRSA {
+		args = append(args, "-o", "iam_role=auto")
+	}
 	if s3fs.region != "" {
 		args = append(args, "-o", fmt.Sprintf("endpoint=%s", s3fs.region))
 	}
 	args = append(args, s3fs.meta.MountOptions...)
-	return fuseMount(target, s3fsCmd, args, nil)
+	return fuseMount(target, s3fsCmd, args, envs)
 }
 
 func writes3fsPass(pwFileContent string) error {

--- a/pkg/s3/client.go
+++ b/pkg/s3/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"sync/atomic"
 
@@ -27,12 +28,16 @@ type s3Client struct {
 
 // Config holds values to configure the driver
 type Config struct {
-	AccessKeyID     string
-	SecretAccessKey string
-	Region          string
-	Endpoint        string
-	Mounter         string
-	Insecure        bool
+	AccessKeyID          string
+	SecretAccessKey      string
+	Region               string
+	Endpoint             string
+	Mounter              string
+	Insecure             bool
+	// IRSA (IAM Roles for Service Accounts) fields
+	UseIRSA              bool
+	RoleArn              string
+	WebIdentityTokenFile string
 }
 
 type FSMeta struct {
@@ -63,9 +68,26 @@ func NewClient(cfg *Config) (*s3Client, error) {
 		tlsConfig.InsecureSkipVerify = true
 		transport.TLSClientConfig = tlsConfig
 	}
+	var creds *credentials.Credentials
+	if client.Config.UseIRSA {
+		// Use IAM credentials from IRSA (projected service account token).
+		// If RoleArn/WebIdentityTokenFile are set in config, override env vars
+		// so the IAM credential provider picks them up.
+		if client.Config.RoleArn != "" {
+			os.Setenv("AWS_ROLE_ARN", client.Config.RoleArn)
+		}
+		if client.Config.WebIdentityTokenFile != "" {
+			os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", client.Config.WebIdentityTokenFile)
+		}
+		creds = credentials.NewIAM("")
+		glog.Infof("Using IRSA for S3 authentication (role=%s)", os.Getenv("AWS_ROLE_ARN"))
+	} else {
+		creds = credentials.NewStaticV4(client.Config.AccessKeyID, client.Config.SecretAccessKey, "")
+	}
+
 	minioClient, err := minio.New(endpoint, &minio.Options{
 		Transport: transport,
-		Creds:     credentials.NewStaticV4(client.Config.AccessKeyID, client.Config.SecretAccessKey, ""),
+		Creds:     creds,
 		Region:    client.Config.Region,
 		Secure:    ssl,
 	})
@@ -79,14 +101,18 @@ func NewClient(cfg *Config) (*s3Client, error) {
 
 func NewClientFromSecret(secret map[string]string) (*s3Client, error) {
 	insecure, _ := strconv.ParseBool(secret["insecure"])
+	useIRSA, _ := strconv.ParseBool(secret["useIRSA"])
 	return NewClient(&Config{
-		AccessKeyID:     secret["accessKeyID"],
-		SecretAccessKey: secret["secretAccessKey"],
-		Region:          secret["region"],
-		Endpoint:        secret["endpoint"],
+		AccessKeyID:          secret["accessKeyID"],
+		SecretAccessKey:      secret["secretAccessKey"],
+		Region:               secret["region"],
+		Endpoint:             secret["endpoint"],
 		// Mounter is set in the volume preferences, not secrets
-		Mounter:  "",
-		Insecure: insecure,
+		Mounter:              "",
+		Insecure:             insecure,
+		UseIRSA:              useIRSA,
+		RoleArn:              secret["roleArn"],
+		WebIdentityTokenFile: secret["webIdentityTokenFile"],
 	})
 }
 

--- a/pkg/s3/client_test.go
+++ b/pkg/s3/client_test.go
@@ -1,0 +1,106 @@
+package s3
+
+import (
+	"os"
+	"testing"
+)
+
+func TestNewClientFromSecret_StaticCreds(t *testing.T) {
+	secret := map[string]string{
+		"accessKeyID":     "AKID",
+		"secretAccessKey": "SECRET",
+		"region":          "us-east-1",
+		"endpoint":        "https://s3.amazonaws.com",
+	}
+	client, err := NewClientFromSecret(secret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.Config.AccessKeyID != "AKID" {
+		t.Errorf("expected AccessKeyID=AKID, got %s", client.Config.AccessKeyID)
+	}
+	if client.Config.SecretAccessKey != "SECRET" {
+		t.Errorf("expected SecretAccessKey=SECRET, got %s", client.Config.SecretAccessKey)
+	}
+	if client.Config.UseIRSA {
+		t.Error("expected UseIRSA=false")
+	}
+}
+
+func TestNewClientFromSecret_IRSA(t *testing.T) {
+	// Set env vars that the IAM credential provider will look for
+	os.Setenv("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/test")
+	os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "/var/run/secrets/token")
+	defer os.Unsetenv("AWS_ROLE_ARN")
+	defer os.Unsetenv("AWS_WEB_IDENTITY_TOKEN_FILE")
+
+	secret := map[string]string{
+		"region":   "us-west-2",
+		"endpoint": "https://s3.us-west-2.amazonaws.com",
+		"useIRSA":  "true",
+	}
+	client, err := NewClientFromSecret(secret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !client.Config.UseIRSA {
+		t.Error("expected UseIRSA=true")
+	}
+	if client.Config.AccessKeyID != "" {
+		t.Errorf("expected empty AccessKeyID, got %s", client.Config.AccessKeyID)
+	}
+}
+
+func TestNewClientFromSecret_IRSAWithExplicitRole(t *testing.T) {
+	secret := map[string]string{
+		"region":               "eu-west-1",
+		"endpoint":             "https://s3.eu-west-1.amazonaws.com",
+		"useIRSA":              "true",
+		"roleArn":              "arn:aws:iam::999999999999:role/custom",
+		"webIdentityTokenFile": "/custom/token/path",
+	}
+	client, err := NewClientFromSecret(secret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !client.Config.UseIRSA {
+		t.Error("expected UseIRSA=true")
+	}
+	if client.Config.RoleArn != "arn:aws:iam::999999999999:role/custom" {
+		t.Errorf("unexpected RoleArn: %s", client.Config.RoleArn)
+	}
+	if client.Config.WebIdentityTokenFile != "/custom/token/path" {
+		t.Errorf("unexpected WebIdentityTokenFile: %s", client.Config.WebIdentityTokenFile)
+	}
+}
+
+func TestNewClientFromSecret_Insecure(t *testing.T) {
+	secret := map[string]string{
+		"accessKeyID":     "AKID",
+		"secretAccessKey": "SECRET",
+		"endpoint":        "https://minio.local:9000",
+		"insecure":        "true",
+	}
+	client, err := NewClientFromSecret(secret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !client.Config.Insecure {
+		t.Error("expected Insecure=true")
+	}
+}
+
+func TestNewClientFromSecret_UseIRSAFalseByDefault(t *testing.T) {
+	secret := map[string]string{
+		"accessKeyID":     "AKID",
+		"secretAccessKey": "SECRET",
+		"endpoint":        "https://s3.amazonaws.com",
+	}
+	client, err := NewClientFromSecret(secret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.Config.UseIRSA {
+		t.Error("UseIRSA should default to false when not specified")
+	}
+}


### PR DESCRIPTION
## Summary

- Add support for [IRSA (IAM Roles for Service Accounts)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) as an alternative to static `accessKeyID`/`secretAccessKey` credentials
- S3 client uses `credentials.NewIAM` for automatic token refresh
- All three mounters (geesefs, rclone, s3fs) pass `AWS_ROLE_ARN`/`AWS_WEB_IDENTITY_TOKEN_FILE` env vars so long-running mounts can refresh credentials independently
- Helm chart and Kubernetes example manifests updated with new fields
- Unit tests added for secret parsing and mounter auth env generation

Addresses #48 and #98

## Usage

```yaml
stringData:
  endpoint: https://s3.amazonaws.com
  region: us-east-1
  useIRSA: "true"
```

## Test plan

- [x] Unit tests pass (`go test ./pkg/s3/ ./pkg/mounter/`)
- [ ] Deploy on EKS with IRSA-annotated service account
- [ ] Verify volume provisioning and mount/unmount with each mounter
- [ ] Verify credential refresh after token rotation