### PR TITLE
Fix mount timeout race: detect unit failure and wait for stale stop

### DIFF
--- a/pkg/mounter/geesefs.go
+++ b/pkg/mounter/geesefs.go
@@ -193,10 +193,21 @@ func (geesefs *geesefsMounter) Mount(target, volumeID string) error {
 				)
 			}
 			// Already mounted at right location, wait for mount
-			return waitForMount(target, 30*time.Second)
+			return waitForMountWithUnitCheck(target, 30*time.Second, conn, unitName)
 		} else {
 			// Stop and garbage collect the unit if automatic collection didn't work for some reason
-			conn.StopUnit(unitName, "replace", nil)
+			stopCh := make(chan string, 1)
+			_, err := conn.StopUnit(unitName, "replace", stopCh)
+			if err != nil {
+				glog.Warningf("Failed to stop stale unit %s: %v", unitName, err)
+			} else {
+				select {
+				case res := <-stopCh:
+					glog.Infof("Stale unit %s stopped with result: %s", unitName, res)
+				case <-time.After(15 * time.Second):
+					glog.Warningf("Timed out waiting for stale unit %s to stop", unitName)
+				}
+			}
 			conn.ResetFailedUnit(unitName)
 		}
 	}
@@ -218,5 +229,5 @@ func (geesefs *geesefsMounter) Mount(target, volumeID string) error {
 	if err != nil {
 		return fmt.Errorf("Error starting systemd unit %s on host: %v", unitName, err)
 	}
-	return waitForMount(target, 30*time.Second)
+	return waitForMountWithUnitCheck(target, 30*time.Second, conn, unitName)
 }

--- a/pkg/mounter/mounter.go
+++ b/pkg/mounter/mounter.go
@@ -1,7 +1,6 @@
 package mounter
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -130,21 +129,63 @@ func FuseUnmount(path string) error {
 	return waitForProcess(process, 20)
 }
 
+// mountCheckFunc checks whether the given path is a mount point.
+// Returns true if it is NOT a mount point.
+type mountCheckFunc func(path string) (bool, error)
+
+// unitStateFunc returns the ActiveState and Result of a systemd unit.
+// Returns ("", "", err) if the unit state cannot be determined.
+type unitStateFunc func() (activeState string, result string, err error)
+
+func defaultMountCheck(path string) (bool, error) {
+	return mount.New("").IsNotMountPoint(path)
+}
+
+func systemdUnitStateFunc(conn *systemd.Conn, unitName string) unitStateFunc {
+	if conn == nil || unitName == "" {
+		return nil
+	}
+	return func() (string, string, error) {
+		unitProps, err := conn.GetAllProperties(unitName)
+		if err != nil {
+			return "", "", err
+		}
+		activeState, _ := unitProps["ActiveState"].(string)
+		result, _ := unitProps["Result"].(string)
+		return activeState, result, nil
+	}
+}
+
 func waitForMount(path string, timeout time.Duration) error {
+	return waitForMountWithUnitCheck(path, timeout, nil, "")
+}
+
+func waitForMountWithUnitCheck(path string, timeout time.Duration, conn *systemd.Conn, unitName string) error {
+	return waitForMountLoop(path, timeout, defaultMountCheck, systemdUnitStateFunc(conn, unitName))
+}
+
+func waitForMountLoop(path string, timeout time.Duration, isMountCheck mountCheckFunc, getUnitState unitStateFunc) error {
 	var elapsed time.Duration
 	var interval = 10 * time.Millisecond
 	for {
-		notMount, err := mount.New("").IsNotMountPoint(path)
+		notMount, err := isMountCheck(path)
 		if err != nil {
 			return err
 		}
 		if !notMount {
 			return nil
 		}
+		// If we have a unit state checker, see if the unit has failed
+		if getUnitState != nil {
+			activeState, result, err := getUnitState()
+			if err == nil && (activeState == "failed" || activeState == "inactive") {
+				return fmt.Errorf("geesefs unit entered state %q (result: %s) before mount appeared at %s", activeState, result, path)
+			}
+		}
 		time.Sleep(interval)
 		elapsed = elapsed + interval
 		if elapsed >= timeout {
-			return errors.New("Timeout waiting for mount")
+			return fmt.Errorf("Timeout waiting for mount at %s after %v", path, timeout)
 		}
 	}
 }

--- a/pkg/mounter/mounter_test.go
+++ b/pkg/mounter/mounter_test.go
@@ -1,0 +1,189 @@
+package mounter
+
+import (
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWaitForMountLoop_ImmediateMount(t *testing.T) {
+	// Mount point exists immediately
+	check := func(path string) (bool, error) {
+		return false, nil // false = IS a mount point
+	}
+	err := waitForMountLoop("/mnt/test", 1*time.Second, check, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestWaitForMountLoop_MountAppearsAfterDelay(t *testing.T) {
+	var calls int32
+	check := func(path string) (bool, error) {
+		n := atomic.AddInt32(&calls, 1)
+		if n >= 3 {
+			return false, nil // mounted after 3 checks
+		}
+		return true, nil // not mounted yet
+	}
+	err := waitForMountLoop("/mnt/test", 1*time.Second, check, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if atomic.LoadInt32(&calls) < 3 {
+		t.Errorf("expected at least 3 mount checks, got %d", calls)
+	}
+}
+
+func TestWaitForMountLoop_Timeout(t *testing.T) {
+	check := func(path string) (bool, error) {
+		return true, nil // never mounts
+	}
+	start := time.Now()
+	err := waitForMountLoop("/mnt/test", 50*time.Millisecond, check, nil)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "Timeout waiting for mount") {
+		t.Errorf("expected timeout message, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "/mnt/test") {
+		t.Errorf("expected path in error message, got: %v", err)
+	}
+	if elapsed < 50*time.Millisecond {
+		t.Errorf("returned too quickly: %v", elapsed)
+	}
+}
+
+func TestWaitForMountLoop_UnitFailed_FailsFast(t *testing.T) {
+	check := func(path string) (bool, error) {
+		return true, nil // never mounts
+	}
+	getUnitState := func() (string, string, error) {
+		return "failed", "exit-code", nil
+	}
+	start := time.Now()
+	err := waitForMountLoop("/mnt/test", 5*time.Second, check, getUnitState)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error when unit fails")
+	}
+	if !strings.Contains(err.Error(), `entered state "failed"`) {
+		t.Errorf("expected failed state in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "exit-code") {
+		t.Errorf("expected result in error, got: %v", err)
+	}
+	// Should fail fast, not wait for the full 5s timeout
+	if elapsed > 1*time.Second {
+		t.Errorf("should have failed fast, but took %v", elapsed)
+	}
+}
+
+func TestWaitForMountLoop_UnitInactive_FailsFast(t *testing.T) {
+	check := func(path string) (bool, error) {
+		return true, nil
+	}
+	getUnitState := func() (string, string, error) {
+		return "inactive", "resources", nil
+	}
+	err := waitForMountLoop("/mnt/test", 5*time.Second, check, getUnitState)
+	if err == nil {
+		t.Fatal("expected error when unit is inactive")
+	}
+	if !strings.Contains(err.Error(), `entered state "inactive"`) {
+		t.Errorf("expected inactive state in error, got: %v", err)
+	}
+}
+
+func TestWaitForMountLoop_UnitFailsAfterDelay(t *testing.T) {
+	// Simulates: unit starts as "activating" then transitions to "failed"
+	var checks int32
+	check := func(path string) (bool, error) {
+		atomic.AddInt32(&checks, 1)
+		return true, nil
+	}
+	getUnitState := func() (string, string, error) {
+		n := atomic.LoadInt32(&checks)
+		if n >= 3 {
+			return "failed", "signal", nil
+		}
+		return "activating", "", nil
+	}
+	err := waitForMountLoop("/mnt/test", 5*time.Second, check, getUnitState)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `entered state "failed"`) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestWaitForMountLoop_UnitActiveAndMounts(t *testing.T) {
+	// Unit stays active, mount eventually appears — success path
+	var calls int32
+	check := func(path string) (bool, error) {
+		n := atomic.AddInt32(&calls, 1)
+		if n >= 3 {
+			return false, nil
+		}
+		return true, nil
+	}
+	getUnitState := func() (string, string, error) {
+		return "active", "", nil
+	}
+	err := waitForMountLoop("/mnt/test", 5*time.Second, check, getUnitState)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestWaitForMountLoop_UnitStateErrorIgnored(t *testing.T) {
+	// If we can't query unit state, we should fall through to timeout
+	// (not crash or fail early)
+	check := func(path string) (bool, error) {
+		return true, nil
+	}
+	getUnitState := func() (string, string, error) {
+		return "", "", fmt.Errorf("dbus connection lost")
+	}
+	err := waitForMountLoop("/mnt/test", 50*time.Millisecond, check, getUnitState)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "Timeout") {
+		t.Errorf("expected timeout, got: %v", err)
+	}
+}
+
+func TestWaitForMountLoop_NilUnitState(t *testing.T) {
+	// Without a unit state checker, behaves like original waitForMount
+	check := func(path string) (bool, error) {
+		return true, nil
+	}
+	err := waitForMountLoop("/mnt/test", 50*time.Millisecond, check, nil)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "Timeout") {
+		t.Errorf("expected timeout, got: %v", err)
+	}
+}
+
+func TestWaitForMountLoop_MountCheckError(t *testing.T) {
+	check := func(path string) (bool, error) {
+		return false, fmt.Errorf("stat /mnt/test: no such file or directory")
+	}
+	err := waitForMountLoop("/mnt/test", 1*time.Second, check, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "no such file or directory") {
+		t.Errorf("expected stat error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- `waitForMount` now polls the systemd unit state alongside the mount check — if geesefs crashes or fails to start, returns immediately with the failure reason instead of waiting 30s and returning a generic "Timeout waiting for mount"
- Stale unit cleanup now waits for `StopUnit` to complete before calling `StartTransientUnit`, preventing a start/stop race
- Extracted mount check and unit state check into injectable functions for testability
- Added 10 unit tests covering: immediate mount, delayed mount, timeout, unit failure (fast fail), unit inactive, delayed failure, active+mount success, dbus errors, nil checker, and mount check errors

Addresses #185 and #96. May partially help with #5 (stale unit race).

## Test plan

- [x] Unit tests pass (`go test ./pkg/mounter/`)
- [ ] Reproduce timeout scenario with geesefs via systemd
- [ ] Verify fast failure with bad credentials / unreachable endpoint
- [ ] Verify stale unit restart after previous mount failure