### PR TITLE
Add PLUGIN_DIR environment variable to csi-s3 container

### DIFF
--- a/deploy/helm/csi-s3/templates/csi-s3.yaml
+++ b/deploy/helm/csi-s3/templates/csi-s3.yaml
@@ -84,6 +84,8 @@ spec:
             - "--nodeid=$(NODE_ID)"
             - "--v=4"
           env:
+            - name: PLUGIN_DIR
+              value: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             - name: NODE_ID


### PR DESCRIPTION
The PLUGIN_DIR environment variable is used by the geesefsMounter and should be set after changing the kubelet directory path.