### PR TITLE
nomad support

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,33 @@ kubectl create -f examples/storageclass.yaml
 
 If something does not work as expected, check the troubleshooting section below.
 
+## Nomad installation
+
+This driver can also run as a Nomad CSI plugin.
+
+### Requirements
+
+* Nomad clients running the Docker task driver
+* `allow_privileged = true` in Nomad Docker plugin config
+* Linux hosts with shared mounts enabled (`/` should be `rshared`)
+
+### Deploy CSI plugin jobs
+
+```bash
+nomad job run deploy/nomad/plugin-s3-controller.nomad.hcl
+nomad job run deploy/nomad/plugin-s3-node.nomad.hcl
+nomad plugin status s3
+```
+
+### Register a volume
+
+```bash
+nomad volume register deploy/nomad/volume-s3.hcl
+nomad volume status s3-demo
+```
+
+Update `deploy/nomad/volume-s3.hcl` with your S3 credentials and endpoint before registering.
+
 ## Additional configuration
 
 ### Bucket

--- a/deploy/nomad/plugin-s3-controller.nomad.hcl
+++ b/deploy/nomad/plugin-s3-controller.nomad.hcl
@@ -1,0 +1,40 @@
+job "plugin-s3-controller" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  constraint {
+    attribute = "${meta.type}"
+    operator  = "set_contains_any"
+    value     = "runner,sandbox,database"
+  }
+
+  group "controller" {
+    count = 1
+
+    task "plugin" {
+      driver = "docker"
+
+      config {
+        image = "cr.yandex/crp9ftr22d26age3hulg/yandex-cloud/csi-s3/csi-s3-driver:0.43.7"
+
+        args = [
+          "--endpoint=unix:///csi/csi.sock",
+          "--nodeid=controller-${node.unique.name}",
+          "--logtostderr",
+          "--v=5",
+        ]
+      }
+
+      csi_plugin {
+        id        = "s3"
+        type      = "controller"
+        mount_dir = "/csi"
+      }
+
+      resources {
+        cpu    = 300
+        memory = 301
+      }
+    }
+  }
+}

--- a/deploy/nomad/plugin-s3-node.nomad.hcl
+++ b/deploy/nomad/plugin-s3-node.nomad.hcl
@@ -1,0 +1,42 @@
+job "plugin-s3-node" {
+  datacenters = ["dc1"]
+  type        = "system"
+  node_pool   = "all"
+
+  constraint {
+    attribute = "${meta.type}"
+    operator  = "set_contains_any"
+    value     = "runner,sandbox,database"
+  }
+
+  group "nodes" {
+    task "plugin" {
+      driver = "docker"
+
+      config {
+        image = "cr.yandex/crp9ftr22d26age3hulg/yandex-cloud/csi-s3/csi-s3-driver:0.43.7"
+
+        args = [
+          "--endpoint=unix:///csi/csi.sock",
+          "--nodeid=${node.unique.name}",
+          "--logtostderr",
+          "--v=5",
+        ]
+
+        # Node plugins must be privileged for bidirectional mount propagation.
+        privileged = true
+      }
+
+      csi_plugin {
+        id        = "s3"
+        type      = "node"
+        mount_dir = "/csi"
+      }
+
+      resources {
+        cpu    = 300
+        memory = 301
+      }
+    }
+  }
+}

--- a/deploy/nomad/volume-s3.hcl
+++ b/deploy/nomad/volume-s3.hcl
@@ -1,0 +1,28 @@
+type      = "csi"
+id        = "s3-demo"
+name      = "s3-demo"
+plugin_id = "s3"
+
+capability {
+  # This driver supports multi-node multi-writer access.
+  access_mode     = "multi-node-multi-writer"
+  attachment_mode = "file-system"
+}
+
+capacity_min = "1GiB"
+capacity_max = "10GiB"
+
+parameters {
+  mounter = "geesefs"
+  # Add --no-systemd if host systemd integration is not available.
+  options = "--memory-limit 1000 --dir-mode 0777 --file-mode 0666 --no-systemd"
+  # bucket = "your-existing-bucket" # Optional. If omitted, bucket name is generated per volume.
+}
+
+secrets {
+  accessKeyID     = "REPLACE_ME"
+  secretAccessKey = "REPLACE_ME"
+  endpoint        = "https://storage.yandexcloud.net"
+  # region        = "eu-central-1" # Optional for non-AWS backends.
+  # insecure      = "true"         # Optional for self-signed TLS endpoints.
+}


### PR DESCRIPTION
## Summary

 Add Nomad CSI support for k8s-csi-s3 using the maintained Yandex driver image (.../csi-s3-driver:0.43.7) instead of the unmaintained ctrox/csi-s3 image.

  ## Why

  ctrox/csi-s3:v1.2.0-rc.2 is stale (2021). We need a maintained CSI S3 plugin for Nomad deployments.

  ## Implementation Notes

  - Added Nomad controller/node CSI job specs and a sample Nomad CSI volume registration.
  - Node plugin runs privileged for mount propagation.
  - Corrected endpoint format to unix:///csi/csi.sock (triple slash), which fixes the probe/socket-not-found failure.
  - Default volume options include --no-systemd for safer Nomad operation unless host systemd integration is explicitly configured.

  ## How To Validate

  1. Run controller and node jobs.
  2. Confirm nomad plugin status s3 is healthy.
  3. Register the sample volume (with real S3 secrets/endpoint).
  4. Schedule a workload using that CSI volume and verify mount/read/write.

  ## Risk

  Low-to-moderate: deployment/runtime integration only; no core driver logic changes.