### PR TITLE
Validate user-supplied GeeseFS options before provisioning and mounting

### DIFF
--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -61,6 +61,16 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, status.Error(codes.InvalidArgument, "Volume Capabilities missing in request")
 	}
 
+	switch params[mounter.TypeKey] {
+	case "s3fs", "rclone":
+		// These mounters have their own option formats.
+	default:
+		meta := getMeta(bucketName, prefix, params)
+		if _, err := mounter.ValidateGeeseFSOptions(meta.MountOptions); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+	}
+
 	glog.V(4).Infof("Got a request to create volume %s", volumeID)
 
 	client, err := s3.NewClientFromSecret(req.GetSecrets())

--- a/pkg/driver/controllerserver_options_test.go
+++ b/pkg/driver/controllerserver_options_test.go
@@ -1,0 +1,56 @@
+package driver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestCreateVolumeRejectsUnsafeGeeseFSOptions(t *testing.T) {
+	for _, mounterType := range []string{"geesefs", "", "unknown"} {
+		for _, options := range []string{
+			"--setuid 0",
+			"--setuid=0",
+			"-setuid=0",
+			`"--setuid" "0"`,
+		} {
+			t.Run(mounterType+"/"+options, func(t *testing.T) {
+				cs := &controllerServer{}
+				req := &csi.CreateVolumeRequest{
+					Name: "test-volume",
+					Parameters: map[string]string{
+						"mounter": mounterType,
+						"options": options,
+					},
+					VolumeCapabilities: []*csi.VolumeCapability{
+						{
+							AccessType: &csi.VolumeCapability_Mount{
+								Mount: &csi.VolumeCapability_MountVolume{},
+							},
+							AccessMode: &csi.VolumeCapability_AccessMode{
+								Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+							},
+						},
+					},
+					// No secrets: validation must precede S3 client creation.
+				}
+
+				resp, err := cs.CreateVolume(context.Background(), req)
+				if status.Code(err) != codes.InvalidArgument {
+					t.Fatalf("expected InvalidArgument, got %v", err)
+				}
+				if got := status.Convert(err).Message(); got !=
+					`geesefs option "--setuid" is not allowed` &&
+					got != `geesefs option "-setuid" is not allowed` {
+					t.Fatalf("unexpected error message: %q", got)
+				}
+				if resp != nil {
+					t.Fatalf("expected no response, got %v", resp)
+				}
+			})
+		}
+	}
+}

--- a/pkg/mounter/geesefs.go
+++ b/pkg/mounter/geesefs.go
@@ -14,8 +14,47 @@ import (
 )
 
 const (
-	geesefsCmd    = "geesefs"
+	geesefsCmd = "geesefs"
 )
+
+// ValidateGeeseFSOptions validates user-supplied GeeseFS options.
+func ValidateGeeseFSOptions(options []string) ([]string, error) {
+	var args []string
+
+	for i := 0; i < len(options); i++ {
+		name, value, hasValue := strings.Cut(options[i], "=")
+
+		switch name {
+		case "--memory-limit", "--dir-mode", "--file-mode":
+			// All currently allowed options require a value.
+		default:
+			return nil, fmt.Errorf("geesefs option %q is not allowed", name)
+		}
+
+		if !hasValue {
+			if i+1 >= len(options) ||
+				strings.HasPrefix(options[i+1], "-") {
+				return nil, fmt.Errorf(
+					"geesefs option %q requires a value", name,
+				)
+			}
+
+			i++
+			value = options[i]
+		}
+
+		if value == "" || strings.HasPrefix(value, "-") {
+			return nil, fmt.Errorf(
+				"invalid value for geesefs option %q", name,
+			)
+		}
+
+		// Preserve separate option and value arguments
+		args = append(args, name, value)
+	}
+
+	return args, nil
+}
 
 // Implements Mounter
 type geesefsMounter struct {
@@ -89,6 +128,11 @@ type execCmd struct {
 }
 
 func (geesefs *geesefsMounter) Mount(target, volumeID string) error {
+	userArgs, err := ValidateGeeseFSOptions(geesefs.meta.MountOptions)
+	if err != nil {
+		return err
+	}
+
 	fullPath := fmt.Sprintf("%s:%s", geesefs.meta.BucketName, geesefs.meta.Prefix)
 	var args []string
 	if geesefs.region != "" {
@@ -99,46 +143,12 @@ func (geesefs *geesefsMounter) Mount(target, volumeID string) error {
 		"--setuid", "65534", // nobody. drop root privileges
 		"--setgid", "65534", // nogroup
 	)
-	var unsafeArgs []string
-	useSystemd := true
-	for i := 0; i < len(geesefs.meta.MountOptions); i++ {
-		opt := geesefs.meta.MountOptions[i]
-		if opt == "--no-systemd" {
-			useSystemd = false
-		} else if len(opt) > 0 && opt[0] == '-' {
-			// Remove unsafe options
-			s := 1
-			if len(opt) > 1 && opt[1] == '-' {
-				s++
-			}
-			key := opt[s:]
-			e := strings.Index(opt, "=")
-			if e >= 0 {
-				key = opt[s:e]
-			}
-			if key == "log-file" || key == "shared-config" || key == "cache" {
-				// Skip options accessing local FS
-				unsafeArgs = append(unsafeArgs, opt)
-				i++
-				if i < len(geesefs.meta.MountOptions) {
-					unsafeArgs = append(unsafeArgs, geesefs.meta.MountOptions[i])
-				}
-			} else if key != "" {
-				args = append(args, opt)
-			}
-		} else if len(opt) > 0 {
-			args = append(args, opt)
-		}
-	}
-	if !useSystemd {
-		// Unsafe options are allowed when running inside the container
-		args = append(args, unsafeArgs...)
-	}
+
+	args = append(args, userArgs...)
+
 	args = append(args, fullPath, target)
 	// Try to start geesefs using systemd so it doesn't get killed when the container exits
-	if !useSystemd {
-		return geesefs.MountDirect(target, args)
-	}
+
 	conn, err := systemd.New()
 	if err != nil {
 		glog.Errorf("Failed to connect to systemd dbus service: %v, starting geesefs directly", err)
@@ -153,21 +163,21 @@ func (geesefs *geesefsMounter) Mount(target, volumeID string) error {
 	if pluginDir == "" {
 		pluginDir = "/var/lib/kubelet/plugins/ru.yandex.s3.csi"
 	}
-	args = append([]string{pluginDir+"/geesefs", "-f", "-o", "allow_other", "--endpoint", geesefs.endpoint}, args...)
-	glog.Info("Starting geesefs using systemd: "+strings.Join(args, " "))
-	unitName := "geesefs-"+systemd.PathBusEscape(volumeID)+".service"
+	args = append([]string{pluginDir + "/geesefs", "-f", "-o", "allow_other", "--endpoint", geesefs.endpoint}, args...)
+	glog.Info("Starting geesefs using systemd: " + strings.Join(args, " "))
+	unitName := "geesefs-" + systemd.PathBusEscape(volumeID) + ".service"
 	newProps := []systemd.Property{
 		systemd.Property{
-			Name: "Description",
-			Value: dbus.MakeVariant("GeeseFS mount for Kubernetes volume "+volumeID),
+			Name:  "Description",
+			Value: dbus.MakeVariant("GeeseFS mount for Kubernetes volume " + volumeID),
 		},
 		systemd.PropExecStart(args, false),
 		systemd.Property{
-			Name: "Environment",
-			Value: dbus.MakeVariant([]string{ "AWS_ACCESS_KEY_ID="+geesefs.accessKeyID, "AWS_SECRET_ACCESS_KEY="+geesefs.secretAccessKey }),
+			Name:  "Environment",
+			Value: dbus.MakeVariant([]string{"AWS_ACCESS_KEY_ID=" + geesefs.accessKeyID, "AWS_SECRET_ACCESS_KEY=" + geesefs.secretAccessKey}),
 		},
 		systemd.Property{
-			Name: "CollectMode",
+			Name:  "CollectMode",
 			Value: dbus.MakeVariant("inactive-or-failed"),
 		},
 	}
@@ -188,7 +198,7 @@ func (geesefs *geesefsMounter) Mount(target, volumeID string) error {
 				// FIXME This may mean that the same bucket&path are used for multiple PVs. Support it somehow
 				return fmt.Errorf(
 					"GeeseFS for volume %v is already mounted on host, but"+
-					" in a different directory. We want %v, but it's in %v",
+						" in a different directory. We want %v, but it's in %v",
 					volumeID, target, curPath,
 				)
 			}

--- a/pkg/mounter/geesefs.go
+++ b/pkg/mounter/geesefs.go
@@ -25,6 +25,12 @@ func ValidateGeeseFSOptions(options []string) ([]string, error) {
 		name, value, hasValue := strings.Cut(options[i], "=")
 
 		switch name {
+		case "--debug_s3", "--debug_fuse":
+			if hasValue {
+				return nil, fmt.Errorf("geesefs option %q does not accept a value", name)
+			}
+			args = append(args, name)
+			continue
 		case "--memory-limit", "--dir-mode", "--file-mode":
 			// All currently allowed options require a value.
 		default:
@@ -163,7 +169,7 @@ func (geesefs *geesefsMounter) Mount(target, volumeID string) error {
 	if pluginDir == "" {
 		pluginDir = "/var/lib/kubelet/plugins/ru.yandex.s3.csi"
 	}
-	args = append([]string{pluginDir + "/geesefs", "-f", "-o", "allow_other", "--endpoint", geesefs.endpoint}, args...)
+	args = append([]string{pluginDir + "/geesefs", "-f", "-o", "allow_other", "--endpoint", geesefs.endpoint, "--log-file", "/dev/stderr"}, args...)
 	glog.Info("Starting geesefs using systemd: " + strings.Join(args, " "))
 	unitName := "geesefs-" + systemd.PathBusEscape(volumeID) + ".service"
 	newProps := []systemd.Property{

--- a/pkg/mounter/geesefs_test.go
+++ b/pkg/mounter/geesefs_test.go
@@ -126,3 +126,74 @@ func TestMountRejectsUnsafeOptions(t *testing.T) {
 		t.Fatalf("got error %q, want %q", got, want)
 	}
 }
+
+func TestValidateGeeseFSOptionsDebugFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:    "s3 debug",
+			options: []string{"--debug_s3"},
+			want:    []string{"--debug_s3"},
+		},
+		{
+			name:    "fuse debug",
+			options: []string{"--debug_fuse"},
+			want:    []string{"--debug_fuse"},
+		},
+		{
+			name: "debug flags do not consume following options",
+			options: []string{
+				"--debug_s3", "--memory-limit", "1000", "--debug_fuse",
+			},
+			want: []string{
+				"--debug_s3", "--memory-limit", "1000", "--debug_fuse",
+			},
+		},
+		{
+			name:    "s3 debug rejects equals value",
+			options: []string{"--debug_s3=true"},
+			wantErr: true,
+		},
+		{
+			name:    "fuse debug rejects equals value",
+			options: []string{"--debug_fuse=false"},
+			wantErr: true,
+		},
+		{
+			name:    "debug rejects separate value",
+			options: []string{"--debug_s3", "true"},
+			wantErr: true,
+		},
+		{
+			name:    "debug does not bypass forbidden options",
+			options: []string{"--debug_s3", "--setuid=0"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ValidateGeeseFSOptions(tt.options)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				if got != nil {
+					t.Fatalf("returned partial arguments on error: %q", got)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/mounter/geesefs_test.go
+++ b/pkg/mounter/geesefs_test.go
@@ -1,0 +1,128 @@
+package mounter
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/yandex-cloud/k8s-csi-s3/pkg/s3"
+)
+
+func TestValidateGeeseFSOptionsForms(t *testing.T) {
+	want := []string{
+		"--memory-limit", "1000",
+		"--dir-mode", "0777",
+		"--file-mode", "0666",
+	}
+
+	tests := []struct {
+		name    string
+		options []string
+	}{
+		{
+			name: "separate values",
+			options: []string{
+				"--memory-limit", "1000",
+				"--dir-mode", "0777",
+				"--file-mode", "0666",
+			},
+		},
+		{
+			name: "equals values",
+			options: []string{
+				"--memory-limit=1000",
+				"--dir-mode=0777",
+				"--file-mode=0666",
+			},
+		},
+		{
+			name: "mixed forms",
+			options: []string{
+				"--memory-limit=1000",
+				"--dir-mode", "0777",
+				"--file-mode=0666",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ValidateGeeseFSOptions(tt.options)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !slices.Equal(got, want) {
+				t.Fatalf("got %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestValidateGeeseFSOptionsRejectsUnsafeFlags(t *testing.T) {
+	flags := []struct {
+		name  string
+		value string
+	}{
+		{"iam", "auto"},
+		{"iam-flavor", "gcp"},
+		{"iam-url", "http://example.invalid"},
+		{"iam-header", "test"},
+		{"endpoint", "https://example.invalid"},
+		{"pprof", "127.0.0.1:6060"},
+		{"setuid", "0"},
+		{"setgid", "0"},
+		{"log-file", "/tmp/geesefs.log"},
+		{"shared-config", "/tmp/config"},
+		{"cache", "/tmp/cache"},
+		{"no-systemd", "true"},
+		{"unknown-option", "value"},
+	}
+
+	for _, flag := range flags {
+		for _, prefix := range []string{"-", "--"} {
+			name := prefix + flag.name
+			forms := []struct {
+				name string
+				args []string
+			}{
+				{"bare", []string{name}},
+				{"separate", []string{name, flag.value}},
+				{"equals", []string{name + "=" + flag.value}},
+			}
+
+			for _, form := range forms {
+				t.Run(name+"/"+form.name, func(t *testing.T) {
+					// Precede the forbidden flag with a valid option.
+					options := append(
+						[]string{"--memory-limit", "1000"},
+						form.args...,
+					)
+
+					got, err := ValidateGeeseFSOptions(options)
+					if err == nil {
+						t.Fatal("expected forbidden option to be rejected")
+					}
+					if got != nil {
+						t.Fatalf("returned partial arguments on error: %q", got)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestMountRejectsUnsafeOptions(t *testing.T) {
+	m := &geesefsMounter{
+		meta: &s3.FSMeta{
+			BucketName:   "test-bucket",
+			MountOptions: []string{"--setuid", "0"},
+		},
+	}
+
+	err := m.Mount(t.TempDir(), "test-volume")
+	if err == nil {
+		t.Fatal("expected unsafe option to be rejected")
+	}
+	if got, want := err.Error(), `geesefs option "--setuid" is not allowed`; got != want {
+		t.Fatalf("got error %q, want %q", got, want)
+	}
+}

--- a/test/test.sh
+++ b/test/test.sh
@@ -5,4 +5,12 @@ export MINIO_SECRET_KEY=DSG643HGDS
 mkdir -p /tmp/minio
 minio server /tmp/minio &>/dev/null &
 sleep 5
-go test ./... -cover -ginkgo.noisySkippings=false -ginkgo.skip="should fail when requesting to create a volume with already existing name and different capacity"
+#go test ./... -cover -ginkgo.noisySkippings=false -ginkgo.skip="should fail when requesting to create a volume with already existing name and different capacity"
+
+# Run ordinary tests in all packages, excluding the Ginkgo suite.
+go test ./... -cover -count=1 -skip '^TestS3Driver$' || exit 1
+
+# Run the Ginkgo suite with its package-specific flags.
+go test ./pkg/driver -cover -count=1 -run '^TestS3Driver$' \
+  -ginkgo.noisySkippings=false \
+  -ginkgo.skip="should fail when requesting to create a volume with already existing name and different capacity"


### PR DESCRIPTION
User-supplied mount options could override driver-controlled GeeseFS
arguments, including --setuid. This change replaces the existing
three-option denylist with an allowlist.

Changes:
- Allow --memory-limit, --dir-mode and --file-mode.
- Accept separate and equals-separated values.
- Reject all other user-supplied flags, including --no-systemd.
- Validate options in CreateVolume before S3 access and in Mount
  before starting GeeseFS.
- Preserve automatic direct mounting if systemd is unavailable.
- Split standard and Ginkgo test invocations to avoid passing
  Ginkgo flags to packages using standard Go tests.

Compatibility:
Configurations using options outside the allowlist will be rejected
during provisioning or a new mount. Existing mounts are not restarted.
Numeric ranges of allowed option values are not validated by this change.

Validation:
- Tests cover allowed argument forms and rejection of unsafe flags
  with single/double dashes and separate/equals-separated values.
- Tests verify rejection in CreateVolume and Mount.
- Container tests passed on Linux amd64 with MinIO and GeeseFS.
  The existing Ginkgo exclusion for creating a volume with an
  existing name and different capacity remains unchanged.

Additional validation:
- Debug-flag unit tests passed.
- A new mount received --debug_s3, --debug_fuse and
  the driver-controlled --log-file /dev/stderr.
- GeeseFS logs appeared in both journal and /var/log/syslog
  on the test node.

Test output:

    ok  github.com/yandex-cloud/k8s-csi-s3/pkg/driver   0.012s  coverage: 10.4% of statements
    ok  github.com/yandex-cloud/k8s-csi-s3/pkg/mounter  0.010s  coverage: 6.8% of statements
    ok  github.com/yandex-cloud/k8s-csi-s3/pkg/driver   3.252s  coverage: 74.2% of statements

The two driver results correspond to separate standard and Ginkgo runs.

Cluster validation:
- A new static PV mount with forbidden options was rejected.
- Dynamic provisioning rejected --setuid=0 with:

    rpc error: code = InvalidArgument desc = geesefs option "--setuid" is not allowed